### PR TITLE
Affichage de la liste des étudiants dans le détail d'un stage

### DIFF
--- a/internship/templates/internship_detail.html
+++ b/internship/templates/internship_detail.html
@@ -58,7 +58,7 @@
         <div class="collapse" id="choice{{ forloop.counter0 }}">
           <ul>
             {% for student in students %}
-              {% if student.choice == i %}
+              {% if student.choice == forloop.parentloop.counter0 %}
                 <li> {{ student.student }}
               {% endif %}
             {% endfor %}


### PR DESCRIPTION
Inform the ticket you are solving in this pull request: #1261 

Le fait d'avoir {% if student.choice == i %} ne fonctionnait pas, car i était le nombre d'étudiant qui avait fait ce choix de stage et non leur ordre de préférence. 
Maintenant oui avec forloop.parentloop.counter0 car on regarde l'itération du tableau des choix