### PR TITLE
Remove the self.client in the tests

### DIFF
--- a/assessments/tests/views/test_pgm_manager_administration.py
+++ b/assessments/tests/views/test_pgm_manager_administration.py
@@ -27,7 +27,7 @@ from datetime import datetime
 
 from django.contrib.auth.models import Permission
 from django.contrib.auth.models import User
-from django.test import TestCase, Client
+from django.test import TestCase
 
 from assessments.views import pgm_manager_administration
 from base.models import program_manager
@@ -59,8 +59,6 @@ class PgmManagerAdministrationTest(TestCase):
         a_year = datetime.now().year
         self.academic_year_previous = AcademicYearFactory(year=a_year-1)
         self.academic_year_current = AcademicYearFactory(year=a_year)
-
-        self.Client = Client()
 
     def test_find_children_entities_from_acronym(self):
         self.assertIsNone(pgm_manager_administration.get_managed_entities(None))

--- a/assistant/tests/utils/test_get_persons.py
+++ b/assistant/tests/utils/test_get_persons.py
@@ -24,14 +24,13 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
-from django.test import TestCase, Client
+from django.test import TestCase
 from base.models.person import Person
 import json
 
 
 class GetPersonsTestCase(TestCase):
     def setUp(self):
-        self.client = Client()
         self.person = Person.objects.create(first_name='person1', last_name='tests', email='person1@tests.com')
         self.person.save()
         self.person = Person.objects.create(first_name='person2', last_name='tests', email='person2@tests.com')

--- a/assistant/tests/utils/test_send_email.py
+++ b/assistant/tests/utils/test_send_email.py
@@ -23,7 +23,7 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
-from django.test import TestCase, RequestFactory, Client
+from django.test import TestCase, RequestFactory
 from django.contrib.auth.models import User
 from assistant.utils import send_email
 from assistant.models.manager import Manager
@@ -44,7 +44,6 @@ from assistant.models.settings import Settings
 class SendEmailTestCase(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
-        self.client = Client()
         self.user = User.objects.create_user(
             username='assistant', email='laurent.buset@uclouvain.be', password='assistant'
         )

--- a/assistant/tests/views/test_assistant_form.py
+++ b/assistant/tests/views/test_assistant_form.py
@@ -23,7 +23,7 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
-from django.test import TestCase, RequestFactory, Client
+from django.test import TestCase, RequestFactory
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 from django.contrib.auth.models import User
@@ -41,7 +41,6 @@ class AssistantFormViewTestCase(TestCase):
 
     def setUp(self):
         self.factory = RequestFactory()
-        self.client = Client()
         self.user = User.objects.create_user(
             username='assistant', email='laurent.buset@uclouvain.be', password='assistant'
         )

--- a/assistant/tests/views/test_messages.py
+++ b/assistant/tests/views/test_messages.py
@@ -28,7 +28,7 @@ from datetime import date
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.db.models.query import QuerySet
-from django.test import TestCase, RequestFactory, Client
+from django.test import TestCase, RequestFactory
 from django.utils import timezone
 
 from assistant.models.enums import message_type
@@ -44,7 +44,6 @@ class MessagesViewTestCase(TestCase):
 
     def setUp(self):
         self.factory = RequestFactory()
-        self.client = Client()
         self.user = User.objects.create_user(
             username='tests', email='tests@uclouvain.be', password='secret'
         )

--- a/dissertation/tests/views/test_dissertation.py
+++ b/dissertation/tests/views/test_dissertation.py
@@ -23,7 +23,7 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
-from django.test import TestCase, Client
+from django.test import TestCase
 from django.core.urlresolvers import reverse
 from base.tests.factories.offer_year import OfferYearFactory
 from base.tests.factories.person import PersonFactory
@@ -39,8 +39,6 @@ from dissertation.tests.factories.proposition_offer import PropositionOfferFacto
 class DissertationViewTestCase(TestCase):
 
     def setUp(self):
-        self.client = Client()
-
         self.manager = AdviserManagerFactory()
         a_person_teacher = PersonFactory.create(first_name='Pierre', last_name='Dupont')
         self.teacher = AdviserTeacherFactory(person=a_person_teacher)
@@ -54,7 +52,7 @@ class DissertationViewTestCase(TestCase):
 
         roles = ['PROMOTEUR', 'CO_PROMOTEUR', 'READER', 'PROMOTEUR', 'ACCOMPANIST']
         status = ['DRAFT', 'COM_SUBMIT', 'EVA_SUBMIT', 'TO_RECEIVE', 'DIR_SUBMIT']
-        
+
         for x in range(0, 5):
             proposition_dissertation = PropositionDissertationFactory(author=self.teacher,
                                                                       creator=a_person_teacher,

--- a/dissertation/tests/views/test_proposition_dissertation.py
+++ b/dissertation/tests/views/test_proposition_dissertation.py
@@ -23,7 +23,7 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
-from django.test import TestCase, RequestFactory, Client
+from django.test import TestCase, RequestFactory
 import random
 from django.core.urlresolvers import reverse
 from dissertation.tests.models import test_proposition_dissertation, test_offer_proposition, test_adviser, \
@@ -36,8 +36,6 @@ from dissertation.models.proposition_role import PropositionRole
 class PropositionDissertationViewTestCase(TestCase):
 
     def setUp(self):
-        self.factory = RequestFactory()
-        self.client = Client()
         #Teacher
         self.adviser_teacher = test_adviser.create_adviser_from_scratch(username='teacher', email='teacher@uclouvain.be',
                                                                         password='teacher', type='PRF')


### PR DESCRIPTION
We don't need to instanciate a new client for the tests, because the TestCase class from django.test, has already done that for us.

Inform the ticket you are solving in this pull request: #
