### PR TITLE
#2422 Remove tabindex=-1 because conflict with link tab CKEDITOR plugin

### DIFF
--- a/base/templates/learning_unit/pedagogy.html
+++ b/base/templates/learning_unit/pedagogy.html
@@ -83,7 +83,7 @@
     </div>
 </div>
 
-<div class="modal fade" id="pedagogy_edit" tabindex="-1" role="dialog" data-backdrop="static"></div>
+<div class="modal fade" id="pedagogy_edit" role="dialog" data-backdrop="static"></div>
 {% endblock %}
 
 {% block script %}


### PR DESCRIPTION
Inform the ticket you are solving in this pull request: #2422 
