### PR TITLE
OSIS-166 Hide researchs tabs for teaching assistants

### DIFF
--- a/assistant/templates/pst_form_view.html
+++ b/assistant/templates/pst_form_view.html
@@ -115,7 +115,6 @@
         {% endfor %}
     </ul>
 </div>
-
 <div class="panel panel-default">
     <div class="panel-body">
   		<div class="panel-default">
@@ -238,78 +237,78 @@
                     </ul>
                 </div>
             {% endif %}
-        {% endif %}
-        <div class="panel-default">
-  			    <div class="panel-heading">
-  				    <h4>{% trans 'research' %}</h4>
-    		    </div>
-        </div>
-        <div class="form-group" style="padding-top: 10px;">
-            <div class="row" style="padding-top: 2px;">
-                <div class="col-md-3">
-                    {% trans 'scientific_internships' %}
+            <div class="panel-default">
+  			        <div class="panel-heading">
+  				        <h4>{% trans 'research' %}</h4>
+    		        </div>
+            </div>
+            <div class="form-group" style="padding-top: 10px;">
+                <div class="row" style="padding-top: 2px;">
+                    <div class="col-md-3">
+                        {% trans 'scientific_internships' %}
+                    </div>
+                    <div class="col-md-9">
+                        {{ mandate.internships|default_if_none:"n/a" }}
+                    </div>
                 </div>
-                <div class="col-md-9">
-                    {{ mandate.internships|default_if_none:"n/a" }}
+                <div class="row" style="padding-top: 2px;">
+                    <div class="col-md-3">
+                        {% trans 'conferences_contributor' %}
+                    </div>
+                    <div class="col-md-3">
+                        {{ mandate.conferences|default_if_none:"n/a" }}
+                    </div>
+                </div>
+                <div class="row" style="padding-top: 2px;">
+                    <div class="col-md-3">
+                        {% trans 'publications_in_progress' %}
+                    </div>
+                    <div class="col-md-9">
+                        {{ mandate.publications|default_if_none:"n/a" }}
+                    </div>
+                </div>
+                <div class="row" style="padding-top: 2px;">
+                    <div class="col-md-3">
+                        {% trans 'awards' %}
+                    </div>
+                    <div class="col-md-9">
+                        {{ mandate.awards|default_if_none:"n/a" }}
+                    </div>
+                </div>
+                <div class="row" style="padding-top: 2px;">
+                    <div class="col-md-3">
+                        {% trans 'framing_participation' %}
+                    </div>
+                    <div class="col-md-9">
+                        {{ mandate.framing|default_if_none:"n/a" }}
+                    </div>
+                </div>
+                <div class="row" style="padding-top: 2px;">
+                    <div class="col-md-3">
+                        {% trans 'remark' %}
+                    </div>
+                    <div class="col-md-9">
+                        {{ mandate.remark|default_if_none:"n/a" }}
+                    </div>
                 </div>
             </div>
-            <div class="row" style="padding-top: 2px;">
-                <div class="col-md-3">
-                    {% trans 'conferences_contributor' %}
+            {% if research_files.all %}
+                <div class="row" style="padding-top: 10px;">
+                    <div class="col-md-12">
+                        {% trans 'dial_publications' %}
+                    </div>
                 </div>
-                <div class="col-md-3">
-                    {{ mandate.conferences|default_if_none:"n/a" }}
+                <div class="row" style="padding-top: 2px;">
+                    <ul>
+                        {% for file in research_files %}
+                        <li>
+                            <a href="{% url 'assistant_file_download' document_file_id=file.id %}">
+                                {{ file.document_file }}</a>
+                        </li>
+                        {% endfor %}
+                    </ul>
                 </div>
-            </div>
-            <div class="row" style="padding-top: 2px;">
-                <div class="col-md-3">
-                    {% trans 'publications_in_progress' %}
-                </div>
-                <div class="col-md-9">
-                    {{ mandate.publications|default_if_none:"n/a" }}
-                </div>
-            </div>
-            <div class="row" style="padding-top: 2px;">
-                <div class="col-md-3">
-                    {% trans 'awards' %}
-                </div>
-                <div class="col-md-9">
-                    {{ mandate.awards|default_if_none:"n/a" }}
-                </div>
-            </div>
-            <div class="row" style="padding-top: 2px;">
-                <div class="col-md-3">
-                    {% trans 'framing_participation' %}
-                </div>
-                <div class="col-md-9">
-                    {{ mandate.framing|default_if_none:"n/a" }}
-                </div>
-            </div>
-            <div class="row" style="padding-top: 2px;">
-                <div class="col-md-3">
-                    {% trans 'remark' %}
-                </div>
-                <div class="col-md-9">
-                    {{ mandate.remark|default_if_none:"n/a" }}
-                </div>
-            </div>
-        </div>
-        {% if research_files.all %}
-            <div class="row" style="padding-top: 10px;">
-                <div class="col-md-12">
-                    {% trans 'dial_publications' %}
-                </div>
-            </div>
-            <div class="row" style="padding-top: 2px;">
-                <ul>
-                    {% for file in research_files %}
-                    <li>
-                        <a href="{% url 'assistant_file_download' document_file_id=file.id %}">
-                            {{ file.document_file }}</a>
-                    </li>
-                    {% endfor %}
-                </ul>
-            </div>
+            {% endif %}
         {% endif %}
         <div class="panel-default">
   			<div class="panel-heading">
@@ -515,14 +514,16 @@
                     {{ mandate.tutoring_percent }} %
                 </div>
             </div>
-            <div class="row" style="padding-top: 2px;">
-                <div class="col-md-5">
-                    {% trans 'research_percent' %}
+            {% if mandate.assistant_type == 'ASSISTANT' %}
+                <div class="row" style="padding-top: 2px;">
+                    <div class="col-md-5">
+                        {% trans 'research_percent' %}
+                    </div>
+                    <div class="col-md-7">
+                        {{ mandate.research_percent }} %
+                    </div>
                 </div>
-                <div class="col-md-7">
-                    {{ mandate.research_percent }} %
-                </div>
-            </div>
+            {% endif %}
             <div class="row" style="padding-top: 2px;">
                 <div class="col-md-5">
                     {% trans 'service_activities_percent' %}


### PR DESCRIPTION
Inform the ticket you are solving in this pull request: #OSIS-166

When a reviewer look at the assistants files, the research tab should not be visible for teaching assistants