### PR TITLE
OSIS-47 Fix bug : bad use of __contains_given_date in entity_version

### DIFF
--- a/base/models/entity_version.py
+++ b/base/models/entity_version.py
@@ -122,7 +122,7 @@ class EntityVersion(SerializableModel):
         if date is None:
             date = timezone.now().date()
 
-        if self._contains_given_date(date):
+        if self.__contains_given_date(date):
             return EntityVersion.objects.current(date).filter(parent=self.entity).select_related('entity')
 
     def find_direct_children(self, date=None):
@@ -180,21 +180,21 @@ class EntityVersion(SerializableModel):
             return find_latest_version_by_entity(self.parent, start_date)
 
         for entity_version in entity_versions:
-            if self._contains_given_date(start_date):
+            if entity_version.__contains_given_date(start_date):
                 return entity_version
 
     def get_parent_version(self, date=None):
         if date is None:
             date = timezone.now().date()
 
-        if self._contains_given_date(date):
+        if self.__contains_given_date(date):
             qs = EntityVersion.objects.current(date).entity(self.parent)
             try:
                 return qs.get()
             except EntityVersion.DoesNotExist:
                 return None
 
-    def _contains_given_date(self, date):
+    def __contains_given_date(self, date):
         if self.start_date and self.end_date:
             return self.start_date <= date <= self.end_date
         elif self.start_date and not self.end_date:


### PR DESCRIPTION
Référence Jira : OSIS-47

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
