### PR TITLE
OSIS-852 Suppression de la learning unit quand on annule une proposition

### DIFF
--- a/base/business/learning_unit_proposal.py
+++ b/base/business/learning_unit_proposal.py
@@ -105,7 +105,11 @@ def _reinitialize_entities_before_proposal(learning_container_year, initial_enti
 
 
 def delete_learning_unit_proposal(learning_unit_proposal):
+    prop_type = learning_unit_proposal.type
+    lu = learning_unit_proposal.learning_unit_year.learning_unit
     learning_unit_proposal.delete()
+    if prop_type == proposal_type.ProposalType.CREATION.name:
+        lu.delete()
 
 
 def _get_difference_of_proposal(learning_unit_yr_proposal):

--- a/base/tests/business/test_learning_unit_proposal.py
+++ b/base/tests/business/test_learning_unit_proposal.py
@@ -93,9 +93,12 @@ class TestLearningUnitProposalCancel(TestCase):
     def test_cancel_proposal_of_type_creation_case_success(self):
         proposal = self._create_proposal(prop_type=proposal_type.ProposalType.CREATION.name,
                                          prop_state=proposal_state.ProposalState.FACULTY.name)
+        lu = proposal.learning_unit_year.learning_unit
         lu_proposal_business.cancel_proposal(proposal, PersonFactory(), send_mail=False)
         self.assertCountEqual(list(mdl_base.proposal_learning_unit.ProposalLearningUnit.objects
                                    .filter(learning_unit_year=self.learning_unit_year)), [])
+        self.assertCountEqual(list(mdl_base.learning_unit.LearningUnit.objects.filter(id=lu.id)),
+                              [])
 
     @patch('base.utils.send_mail.send_mail_after_the_learning_unit_proposal_cancellation')
     def test_cancel_proposals_of_type_suppression(self, mock_send_mail):


### PR DESCRIPTION
Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
