### PR TITLE
Osis 603 - ajout d'une exclusion pour le comptage des places disponibles pour le mémoire

### DIFF
--- a/dissertation/models/dissertation.py
+++ b/dissertation/models/dissertation.py
@@ -175,7 +175,8 @@ def count_by_proposition(prop_dissert):
     return Dissertation.objects.filter(proposition_dissertation=prop_dissert)\
         .filter(active=True)\
         .filter(offer_year_start__academic_year=current_academic_year)\
-        .exclude(status='DRAFT')\
+        .exclude(status='DRAFT') \
+        .exclude(status='DIR_KO') \
         .count()
 
 


### PR DESCRIPTION
Référence Jira : OSIS- 603

Ajout d'une exclusion pour le comptage des places disponibles pour le mémoire. 
Modification effectué suite à un test failed.