### PR TITLE
Correction de set up des tests pour éviter des cas ou la création du …

### DIFF
--- a/base/tests/model_forms/learning_unit/test_learning_unit_year.py
+++ b/base/tests/model_forms/learning_unit/test_learning_unit_year.py
@@ -95,15 +95,17 @@ class TestLearningUnitYearModelFormSave(TestCase):
         self.faculty_manager = PersonFactory()
         self.faculty_manager.user.groups.add(Group.objects.get(name=FACULTY_MANAGER_GROUP))
 
+        self.current_academic_year = create_current_academic_year()
+
         self.learning_container = LearningContainerFactory()
         self.learning_unit = LearningUnitFactory(learning_container=self.learning_container)
         self.learning_container_year = LearningContainerYearFactory(learning_container=self.learning_container,
-                                                                    container_type=learning_container_year_types.COURSE)
+                                                                    container_type=learning_container_year_types.COURSE,
+                                                                    academic_year=self.current_academic_year)
         self.form = LearningUnitYearModelForm(data=None, person=self.central_manager, subtype=FULL)
         self.learning_unit_year_to_update = LearningUnitYearFactory(
             learning_unit=self.learning_unit, learning_container_year=self.learning_container_year)
 
-        self.current_academic_year = create_current_academic_year()
         self.post_data = {
             'acronym_0': 'L',
             'acronym_1': 'OSIS9001',


### PR DESCRIPTION
…learning_container_year créait un academic_year identique à l'année en cours créé plus tard dans le set up

	modifié :         base/tests/model_forms/learning_unit/test_learning_unit_year.py

Référence Jira : OSIS-1061

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
