### PR TITLE
OSIS-1057 Correction du initial data pour ne pas calculer le champs s…

### DIFF
--- a/base/forms/learning_unit_proposal.py
+++ b/base/forms/learning_unit_proposal.py
@@ -139,6 +139,7 @@ class ProposalBaseForm:
         }
         if self.proposal:
             initial['type'] = self.proposal.type
+            initial['state'] = self.proposal.state
         return initial
 
     def get_context(self):

--- a/base/tests/views/test_learning_unit_proposal.py
+++ b/base/tests/views/test_learning_unit_proposal.py
@@ -831,6 +831,21 @@ class TestEditProposal(TestCase):
         self.assertEqual(template, 'learning_unit/proposal/update_modification.html')
         self.assertIsInstance(context['form_proposal'], ProposalLearningUnitForm)
 
+    @mock.patch('base.views.layout.render')
+    def test_edit_proposal_get_as_central_manager_with_instance(self, mock_render):
+        request_factory = RequestFactory()
+
+        request = request_factory.get(self.url)
+
+        request.user = self.person.user
+        update_learning_unit_proposal(request, self.learning_unit_year.id)
+
+        self.assertTrue(mock_render.called)
+        request, template, context = mock_render.call_args[0]
+        self.assertEqual(template, 'learning_unit/proposal/update_modification.html')
+        self.assertIsInstance(context['form_proposal'], ProposalLearningUnitForm)
+        self.assertEqual(context['form_proposal'].initial['state'], str(ProposalState.FACULTY.name))
+
     def get_valid_data(self):
         return {
             'acronym_0': 'L',


### PR DESCRIPTION
…tate lors de l'edition d'une proposition autre que Suppression

	modifié :         base/forms/learning_unit_proposal.py

Référence Jira : OSIS-1057

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
