### PR TITLE
OSIS-1210 Volumes in partim can be equal to corresponding in parent

### DIFF
--- a/base/forms/learning_unit/edition_volume.py
+++ b/base/forms/learning_unit/edition_volume.py
@@ -142,7 +142,7 @@ class VolumeEditionForm(forms.Form):
     def validate_parent_partim_component(self, parent_data):
         self._parent_data = parent_data
 
-        self._compare_parent_partim('volume_total', 'vol_tot_full_must_be_greater_than_partim', lower_or_equal=True)
+        self._compare_parent_partim('volume_total', 'vol_tot_full_must_be_greater_than_partim')
         self._compare_parent_partim('volume_q1', 'vol_q1_full_must_be_greater_or_equal_to_partim')
         self._compare_parent_partim('volume_q2', 'vol_q2_full_must_be_greater_or_equal_to_partim')
         self._compare_parent_partim('planned_classes', 'planned_classes_full_must_be_greater_or_equal_to_partim')
@@ -158,22 +158,11 @@ class VolumeEditionForm(forms.Form):
         if key in self._parent_data and key in self.cleaned_data:
             self._compare_parent_partim(key, 'entity_requirement_full_must_be_greater_or_equal_to_partim')
 
-    def _compare_parent_partim(self, key, msg, lower_or_equal=False):
+    def _compare_parent_partim(self, key, msg):
         partim_data = self.cleaned_data or self.initial
-        condition = self._compare(self._parent_data[key],  partim_data[key], lower_or_equal)
-
-        if condition:
+        if self._parent_data[key] < partim_data[key]:
             self.add_error(key, _(msg))
 
-    @staticmethod
-    def _compare(value_parent, value_partim, lower_or_equal):
-        if value_parent == 0 and value_partim == 0:
-            condition = False
-        elif lower_or_equal:
-            condition = value_parent <= value_partim
-        else:
-            condition = value_parent < value_partim
-        return condition
 
     def save(self, postponement):
         if not self.changed_data:

--- a/base/forms/learning_unit/edition_volume.py
+++ b/base/forms/learning_unit/edition_volume.py
@@ -142,7 +142,7 @@ class VolumeEditionForm(forms.Form):
     def validate_parent_partim_component(self, parent_data):
         self._parent_data = parent_data
 
-        self._compare_parent_partim('volume_total', 'vol_tot_full_must_be_greater_than_partim')
+        self._compare_parent_partim('volume_total', 'vol_tot_full_must_be_greater_or_equal_than_partim')
         self._compare_parent_partim('volume_q1', 'vol_q1_full_must_be_greater_or_equal_to_partim')
         self._compare_parent_partim('volume_q2', 'vol_q2_full_must_be_greater_or_equal_to_partim')
         self._compare_parent_partim('planned_classes', 'planned_classes_full_must_be_greater_or_equal_to_partim')

--- a/base/forms/learning_unit/edition_volume.py
+++ b/base/forms/learning_unit/edition_volume.py
@@ -163,7 +163,6 @@ class VolumeEditionForm(forms.Form):
         if self._parent_data[key] < partim_data[key]:
             self.add_error(key, _(msg))
 
-
     def save(self, postponement):
         if not self.changed_data:
             return None

--- a/base/locale/en/LC_MESSAGES/django.po
+++ b/base/locale/en/LC_MESSAGES/django.po
@@ -1873,7 +1873,7 @@ msgid "vol_tot_req_entities_not_equal_to_vol_tot_mult_cp"
 msgstr "Vol.global = Vol.tot * C.P"
 
 msgid "vol_tot_full_must_be_greater_than_partim"
-msgstr "Vol.tot [Full] > Vol.tot [Partim]"
+msgstr "Vol.tot [Full] >= Vol.tot [Partim]"
 
 msgid "vol_q1_full_must_be_greater_or_equal_to_partim"
 msgstr "Q1 [Full] >= Q1 [Partim]"

--- a/base/locale/en/LC_MESSAGES/django.po
+++ b/base/locale/en/LC_MESSAGES/django.po
@@ -1872,7 +1872,7 @@ msgstr "Vol.tot requirement is not equals to sum of requirement volumes"
 msgid "vol_tot_req_entities_not_equal_to_vol_tot_mult_cp"
 msgstr "Vol.global = Vol.tot * C.P"
 
-msgid "vol_tot_full_must_be_greater_than_partim"
+msgid "vol_tot_full_must_be_greater_or_equal_than_partim"
 msgstr "Vol.tot [Full] >= Vol.tot [Partim]"
 
 msgid "vol_q1_full_must_be_greater_or_equal_to_partim"

--- a/base/locale/fr_BE/LC_MESSAGES/django.po
+++ b/base/locale/fr_BE/LC_MESSAGES/django.po
@@ -1881,7 +1881,7 @@ msgstr "Le volume total de charge n'est pas égal à la somme des volumes de cha
 msgid "vol_tot_req_entities_not_equal_to_vol_tot_mult_cp"
 msgstr "Vol.global = Vol.tot * C.P"
 
-msgid "vol_tot_full_must_be_greater_than_partim"
+msgid "vol_tot_full_must_be_greater_or_equal_than_partim"
 msgstr "Vol.tot du cours principal >= Vol.tot du partim"
 
 msgid "vol_q1_full_must_be_greater_or_equal_to_partim"

--- a/base/locale/fr_BE/LC_MESSAGES/django.po
+++ b/base/locale/fr_BE/LC_MESSAGES/django.po
@@ -1882,7 +1882,7 @@ msgid "vol_tot_req_entities_not_equal_to_vol_tot_mult_cp"
 msgstr "Vol.global = Vol.tot * C.P"
 
 msgid "vol_tot_full_must_be_greater_than_partim"
-msgstr "Vol.tot du cours principal > Vol.tot du partim"
+msgstr "Vol.tot du cours principal >= Vol.tot du partim"
 
 msgid "vol_q1_full_must_be_greater_or_equal_to_partim"
 msgstr "Q1 du cours principal >= Q1 du partim"

--- a/base/tests/forms/test_edition_form.py
+++ b/base/tests/forms/test_edition_form.py
@@ -281,7 +281,7 @@ class TestVolumeEditionFormsetContainer(TestCase):
         self.assertFalse(volume_edition_formset_container.is_valid())
         self.assertEqual(
             volume_edition_formset_container.formsets[self.learning_unit_year_partim].errors[0].get('volume_total'),
-            [_('vol_tot_full_must_be_greater_than_partim')]
+            [_('vol_tot_full_must_be_greater_or_equal_than_partim')]
         )
 
 

--- a/base/tests/forms/test_edition_form.py
+++ b/base/tests/forms/test_edition_form.py
@@ -145,13 +145,6 @@ class TestVolumeEditionForm(TestCase):
             actual_entity_fields = form.get_entity_fields()
             self.assertEqual(len(actual_entity_fields), 3)
 
-    def test_compare(self):
-        self.assertFalse(VolumeEditionForm._compare(0, 0, False))
-        self.assertTrue(VolumeEditionForm._compare(12, 14, False))
-        self.assertTrue(VolumeEditionForm._compare(12, 12, True))
-        self.assertFalse(VolumeEditionForm._compare(12, 12, False))
-
-
     def test_warning_volumes(self):
         learning_component_year_0 = LearningComponentYear.objects.filter(
             learningunitcomponent__learning_unit_year=self.first_learning_unit_year
@@ -276,6 +269,10 @@ class TestVolumeEditionFormsetContainer(TestCase):
 
         data_forms = get_valid_formset_data(self.learning_unit_year_full.acronym)
         data_forms.update(get_valid_formset_data(self.learning_unit_year_partim.acronym))
+        data_forms.update({'LDROI1200A-0-volume_total': 3})
+        data_forms.update({'LDROI1200A-0-volume_q2': 3})
+        data_forms.update({'LDROI1200A-0-volume_requirement_entity': 2})
+        data_forms.update({'LDROI1200A-0-volume_total_requirement_entities': 3})
 
         volume_edition_formset_container = VolumeEditionFormsetContainer(
             request_factory.post(None, data=data_forms),
@@ -283,9 +280,23 @@ class TestVolumeEditionFormsetContainer(TestCase):
 
         self.assertFalse(volume_edition_formset_container.is_valid())
         self.assertEqual(
-            volume_edition_formset_container.formsets[self.learning_unit_year_partim].errors[0],
-            {'volume_total': [_('vol_tot_full_must_be_greater_than_partim')]}
+            volume_edition_formset_container.formsets[self.learning_unit_year_partim].errors[0].get('volume_total'),
+            [_('vol_tot_full_must_be_greater_than_partim')]
         )
+
+
+    def test_post_volume_edition_formset_container__vol_tot_full_can_be_equal_to_partim(self):
+        request_factory = RequestFactory()
+
+        data_forms = get_valid_formset_data(self.learning_unit_year_full.acronym)
+        data_forms.update(get_valid_formset_data(self.learning_unit_year_partim.acronym))
+
+        volume_edition_formset_container = VolumeEditionFormsetContainer(
+            request_factory.post(None, data=data_forms),
+            self.learning_units_with_context, self.central_manager)
+
+        self.assertTrue(volume_edition_formset_container.is_valid())
+
 
     def test_get_volume_edition_formset_container_as_faculty_manager(self):
         request_factory = RequestFactory()
@@ -329,24 +340,6 @@ def get_valid_formset_data(prefix, is_partim=False):
 
     for i in range(2):
         form_data.update({'{}-{}'.format(i, k): v for k, v in data.items()})
-
-    form_data.update(
-        {'INITIAL_FORMS': '0',
-         'MAX_NUM_FORMS': '1000',
-         'MIN_NUM_FORMS': '0',
-         'TOTAL_FORMS': '2'}
-    )
-    return {'{}-{}'.format(prefix, k): v for k, v in form_data.items()}
-
-
-def _get_wrong_formset_data(prefix, is_partim=False):
-    form_data = {}
-    data = _get_valid_data() if not is_partim else _get_valid_partim_data()
-
-    for i in range(2):
-        form_data.update({'{}-{}'.format(i, k): v for k, v in data.items()})
-        if is_partim:
-            form_data['{}-{}'.format(i, 'volume_q1')] = 6
 
     form_data.update(
         {'INITIAL_FORMS': '0',

--- a/base/tests/views/test_learning_unit_edition.py
+++ b/base/tests/views/test_learning_unit_edition.py
@@ -478,7 +478,6 @@ class TestLearningUnitVolumesManagement(TestCase):
 
         response = learning_unit_volumes_management(request, self.learning_unit_year.id)
         prefix = self.learning_unit_year_partim.acronym
-        self.maxDiff = None
         self.assertJSONEqual(response.content.decode("utf-8"),
                              {"errors":
                                   {

--- a/base/tests/views/test_learning_unit_edition.py
+++ b/base/tests/views/test_learning_unit_edition.py
@@ -434,6 +434,10 @@ class TestLearningUnitVolumesManagement(TestCase):
         request_factory = RequestFactory()
         data = get_valid_formset_data(self.learning_unit_year.acronym)
         data.update(get_valid_formset_data(self.learning_unit_year_partim.acronym))
+        data.update({'LDROI1200A-0-volume_total': 3})
+        data.update({'LDROI1200A-0-volume_q2': 3})
+        data.update({'LDROI1200A-0-volume_requirement_entity': 2})
+        data.update({'LDROI1200A-0-volume_total_requirement_entities': 3})
 
         request = request_factory.post(reverse(learning_unit_volumes_management,
                                                args=[self.learning_unit_year.id]),
@@ -449,8 +453,8 @@ class TestLearningUnitVolumesManagement(TestCase):
         request, template, context = mock_render.call_args[0]
         self.assertEqual(template, 'learning_unit/volumes_management.html')
         self.assertEqual(
-            context['formsets'][self.learning_unit_year_partim].errors[0],
-            {'volume_total': [_('vol_tot_full_must_be_greater_than_partim')]}
+            context['formsets'][self.learning_unit_year_partim].errors[0].get('volume_total'),
+            [_('vol_tot_full_must_be_greater_or_equal_than_partim')]
         )
 
     @mock.patch('base.models.program_manager.is_program_manager')
@@ -460,6 +464,10 @@ class TestLearningUnitVolumesManagement(TestCase):
         request_factory = RequestFactory()
         data = get_valid_formset_data(self.learning_unit_year.acronym)
         data.update(get_valid_formset_data(self.learning_unit_year_partim.acronym))
+        data.update({'LDROI1200A-0-volume_total': 3})
+        data.update({'LDROI1200A-0-volume_q2': 3})
+        data.update({'LDROI1200A-0-volume_requirement_entity': 2})
+        data.update({'LDROI1200A-0-volume_total_requirement_entities': 3})
 
         request = request_factory.post(reverse(learning_unit_volumes_management,
                                                args=[self.learning_unit_year.id]),
@@ -470,10 +478,17 @@ class TestLearningUnitVolumesManagement(TestCase):
 
         response = learning_unit_volumes_management(request, self.learning_unit_year.id)
         prefix = self.learning_unit_year_partim.acronym
+        self.maxDiff = None
         self.assertJSONEqual(response.content.decode("utf-8"),
                              {"errors":
-                                  {prefix+"-0-volume_total": [_("vol_tot_full_must_be_greater_than_partim")],
-                                   prefix+"-1-volume_total": [_("vol_tot_full_must_be_greater_than_partim")]}
+                                  {
+                                    prefix+"-0-volume_total":
+                                        [_("vol_tot_full_must_be_greater_or_equal_than_partim")],
+                                    prefix+"-0-volume_q2":
+                                        [_("vol_q2_full_must_be_greater_or_equal_to_partim")],
+                                    prefix+"-0-volume_requirement_entity":
+                                        [_("entity_requirement_full_must_be_greater_or_equal_to_partim")]
+                                  }
                               })
 
     def test_with_user_not_logged(self):


### PR DESCRIPTION
Référence Jira : OSIS-1210 : Volumes in partim can be equal to corresponding in parent

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
