### PR TITLE
OSIS-1341 Change default acronym for LECTURING and PRATICAL composants

### DIFF
--- a/base/forms/learning_unit/learning_unit_create.py
+++ b/base/forms/learning_unit/learning_unit_create.py
@@ -41,8 +41,8 @@ from base.models.learning_unit_year import LearningUnitYear, MAXIMUM_CREDITS
 from reference.models.language import find_all_languages
 
 DEFAULT_ACRONYM_COMPONENT = {
-    LECTURING: "CM1",
-    PRACTICAL_EXERCISES: "TP1",
+    LECTURING: "PM1",
+    PRACTICAL_EXERCISES: "PP1",
     None: "NT1"
 }
 

--- a/base/tests/forms/test_learning_unit_create_2.py
+++ b/base/tests/forms/test_learning_unit_create_2.py
@@ -34,7 +34,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from base.forms.learning_unit.entity_form import EntityContainerBaseForm
 from base.forms.learning_unit.learning_unit_create import LearningUnitYearModelForm, \
-    LearningUnitModelForm, LearningContainerYearModelForm, LearningContainerModelForm
+    LearningUnitModelForm, LearningContainerYearModelForm, LearningContainerModelForm, DEFAULT_ACRONYM_COMPONENT
 from base.forms.learning_unit.learning_unit_create_2 import FullForm, FACULTY_OPEN_FIELDS
 from base.models.academic_year import AcademicYear
 from base.models.entity_component_year import EntityComponentYear
@@ -46,6 +46,7 @@ from base.models.enums.entity_container_year_link_type import ADDITIONAL_REQUIRE
     ADDITIONAL_REQUIREMENT_ENTITY_2
 from base.models.enums.entity_type import FACULTY
 from base.models.enums.internship_subtypes import TEACHING_INTERNSHIP
+from base.models.enums.learning_component_year_type import LECTURING, PRACTICAL_EXERCISES
 from base.models.enums.learning_container_year_types import MASTER_THESIS, INTERNSHIP
 from base.models.enums.learning_unit_year_periodicity import ANNUAL
 from base.models.enums.organization_type import MAIN
@@ -506,6 +507,14 @@ class TestFullFormSave(LearningUnitFullFormContextMixin):
             current_count = self._count_records(model_class)
             self.assertEqual(current_count, initial_count, model_class.objects.all())
 
+    def test_default_acronym_component(self):
+        default_acronym_component={
+            LECTURING: "PM1",
+            PRACTICAL_EXERCISES: "PP1",
+            None: "NT1"
+        }
+        self.assertEqual(default_acronym_component, DEFAULT_ACRONYM_COMPONENT)
+
     def test_when_create_instance(self):
         initial_counts = self._get_initial_counts()
         acronym = 'LAGRO1200'
@@ -532,6 +541,12 @@ class TestFullFormSave(LearningUnitFullFormContextMixin):
         self.assertEqual(LearningComponentYear.objects.filter(
             learning_container_year=saved_luy.learning_container_year
         ).count(), 2)
+        self.assertEqual(
+            LearningComponentYear.objects.get(
+                learning_container_year=saved_luy.learning_container_year, type=LECTURING).acronym, "PM1")
+        self.assertEqual(
+            LearningComponentYear.objects.get(
+                learning_container_year=saved_luy.learning_container_year, type=PRACTICAL_EXERCISES).acronym, "PP1")
 
     def test_when_type_is_internship(self):
         EntityContainerYear.objects.filter(type__in=[ADDITIONAL_REQUIREMENT_ENTITY_1, ADDITIONAL_REQUIREMENT_ENTITY_2],
@@ -556,6 +571,12 @@ class TestFullFormSave(LearningUnitFullFormContextMixin):
         self.assertEqual(LearningComponentYear.objects.filter(
             learning_container_year=saved_luy.learning_container_year
         ).count(), 2)
+        self.assertEqual(
+            LearningComponentYear.objects.get(
+                learning_container_year=saved_luy.learning_container_year, type=LECTURING).acronym, "PM1")
+        self.assertEqual(
+            LearningComponentYear.objects.get(
+                learning_container_year=saved_luy.learning_container_year, type=PRACTICAL_EXERCISES).acronym, "PP1")
 
     def test_when_type_is_dissertation(self):
         EntityContainerYear.objects.filter(type__in=[ADDITIONAL_REQUIREMENT_ENTITY_1, ADDITIONAL_REQUIREMENT_ENTITY_2],
@@ -578,6 +599,9 @@ class TestFullFormSave(LearningUnitFullFormContextMixin):
         self.assertEqual(LearningComponentYear.objects.filter(
             learning_container_year=saved_luy.learning_container_year
         ).count(), 1)
+        self.assertEqual(
+            LearningComponentYear.objects.get(
+                learning_container_year=saved_luy.learning_container_year, type=LECTURING).acronym, "PM1")
 
     def _assert_correctly_create_records_in_all_learning_unit_structure(self, initial_counts):
         # NUMBER_OF_POSTPONMENTS = 7


### PR DESCRIPTION
	modifié :         base/forms/learning_unit/learning_unit_create.py

Référence Jira : OSIS-1341

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
