### PR TITLE
OSIS-1369 Permettre le report des UE bornées et afficher un warning s…

### DIFF
--- a/base/forms/learning_unit/entity_form.py
+++ b/base/forms/learning_unit/entity_form.py
@@ -86,10 +86,6 @@ class EntityContainerYearModelForm(forms.ModelForm):
         if not entity:
             return
 
-        if not entity_version.get_by_entity_and_date(entity, start_date):
-            self.add_error('entity', _("The linked entity does not exist at the start date of the "
-                                       "academic year linked to this learning unit"))
-
 
 class RequirementEntityContainerYearModelForm(EntityContainerYearModelForm):
     entity_type = REQUIREMENT_ENTITY

--- a/base/locale/en/LC_MESSAGES/django.po
+++ b/base/locale/en/LC_MESSAGES/django.po
@@ -2847,7 +2847,7 @@ msgstr "Proposals date"
 msgid "search_type"
 msgstr "Search type"
 
-msgid "The linked entity does not exist at the start date of the academic year linked to this learning unit"
+msgid "The linked %(entity)s does not exist at the start date of the academic year linked to this learning unit"
 msgstr ""
 
 msgid "COURSE_ENROLLMENT"

--- a/base/locale/fr_BE/LC_MESSAGES/django.po
+++ b/base/locale/fr_BE/LC_MESSAGES/django.po
@@ -2849,8 +2849,8 @@ msgstr "Date proposition"
 msgid "search_type"
 msgstr "Type de recherche"
 
-msgid "The linked entity does not exist at the start date of the academic year linked to this learning unit"
-msgstr "L'entité liée n'existe pas à la date de début de l'année académique liée à cette unité d'enseignement"
+msgid "The linked %(entity)s does not exist at the start date of the academic year linked to this learning unit"
+msgstr "L'%(entity)s liée n'existe pas à la date de début de l'année académique liée à cette unité d'enseignement"
 
 msgid "COURSE_ENROLLMENT"
 msgstr "Inscription aux cours"

--- a/base/models/learning_unit_year.py
+++ b/base/models/learning_unit_year.py
@@ -243,8 +243,9 @@ class LearningUnitYear(SerializableModel):
         return self.subtype == learning_unit_year_subtypes.PARTIM
 
     def get_entity(self, entity_type):
-        entity_container_yr = entity_container_year.search(link_type=entity_type,
-                                                           learning_container_year=self.learning_container_year).get()
+        entity_container_yr = mdl_entity_container_year.search(
+            link_type=entity_type, learning_container_year=self.learning_container_year
+        ).get()
         return entity_container_yr.entity if entity_container_yr else None
 
     def clean(self):

--- a/base/models/learning_unit_year.py
+++ b/base/models/learning_unit_year.py
@@ -32,7 +32,7 @@ from django.db.models import Q
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
-from base.models import entity_container_year
+from base.models import entity_container_year as mdl_entity_container_year
 from base.models.academic_year import current_academic_year, compute_max_academic_year_adjournment, AcademicYear, \
     MAX_ACADEMIC_YEAR_FACULTY
 from base.models.enums import active_status, learning_container_year_types
@@ -271,6 +271,7 @@ class LearningUnitYear(SerializableModel):
             self._warnings.extend(self._check_partim_parent_periodicity())
             self._warnings.extend(self._check_learning_component_year_warnings())
             self._warnings.extend(self._check_learning_container_year_warnings())
+            self._warnings.extend(self._check_entity_container_year_warnings())
         return self._warnings
 
     def _check_partim_parent_credits(self):
@@ -320,6 +321,13 @@ class LearningUnitYear(SerializableModel):
 
     def _check_learning_container_year_warnings(self):
         return self.learning_container_year.warnings
+
+    def _check_entity_container_year_warnings(self):
+        _warnings = []
+        entity_container_years = mdl_entity_container_year.find_by_learning_container_year(self.learning_container_year)
+        for entity_container_year in entity_container_years:
+            _warnings.extend(entity_container_year.warnings)
+        return _warnings
 
     def is_external(self):
         return hasattr(self, "externallearningunityear")


### PR DESCRIPTION
…upplémentaire + test

	modifié :         base/forms/learning_unit/entity_form.py
	modifié :         base/locale/en/LC_MESSAGES/django.po
	modifié :         base/locale/fr_BE/LC_MESSAGES/django.po
	modifié :         base/models/entity_container_year.py
	modifié :         base/models/learning_unit_year.py
	modifié :         base/tests/model_forms/learning_unit/test_learning_unit_year.py

Référence Jira : OSIS-1369

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
