### PR TITLE
Fixed error with debug toolbar and cache

### DIFF
--- a/base/utils/cache.py
+++ b/base/utils/cache.py
@@ -29,6 +29,8 @@ from django.conf import settings
 from django.core.cache import caches, InvalidCacheBackendError
 from functools import wraps
 
+from django.http import QueryDict
+
 CACHE_FILTER_TIMEOUT = None
 PREFIX_CACHE_KEY = 'cache_filter'
 
@@ -66,7 +68,9 @@ def _save_filter_to_cache(request, exclude_params=None):
 def _restore_filter_from_cache(request):
     cached_value = _get_from_cache(request)
     if cached_value:
-        request.GET = {**request.GET.dict(), **cached_value}
+
+        request.GET = QueryDict(mutable=True)
+        request.GET.update({**request.GET.dict(), **cached_value})
 
 
 def _get_from_cache(request):


### PR DESCRIPTION
The cache utils returns a simple dict in place of a querydict.
