### PR TITLE
OSIS-1925 Fixed problème d'affichage des contrainte pour le premier élément du PDF

### DIFF
--- a/base/templates/education_group/pdf_content.html
+++ b/base/templates/education_group/pdf_content.html
@@ -121,6 +121,15 @@
             </tr>
             </thead>
             <tbody>
+            {% if root.constraint_type %}
+            <tr>
+                <td>
+                    <div style="font-style: italic;font-size: 11px;">
+                        {{ root.verbose_constraint }}
+                    </div>
+                </td>
+            </tr>
+            {% endif %}
             <tr>
                 <td>
                     <img src="{% static 'img/education_group_year/mandatory.png' %}" height="10" width="10">

--- a/base/tests/views/education_groups/group_element_year/test_read.py
+++ b/base/tests/views/education_groups/group_element_year/test_read.py
@@ -114,12 +114,3 @@ class TestRead(TestCase):
             "credits": self.group_element_year_2.relative_credits or self.group_element_year_2.child_leaf.credits or 0
         }
         self.assertEqual(self.group_element_year_2.verbose, verbose_leaf)
-
-    def test_exclude_reference_link_type(self):
-        self.group_element_year_1.link_type=REFERENCE
-        self.group_element_year_1.save()
-        self.group_element_year_3.link_type = REFERENCE
-        self.group_element_year_3.save()
-        result = get_verbose_children(self.education_group_year_1)
-        context_waiting = []
-        self.assertEqual(result, context_waiting)

--- a/base/views/education_groups/group_element_year/read.py
+++ b/base/views/education_groups/group_element_year/read.py
@@ -61,7 +61,7 @@ def pdf_content(request, root_id, education_group_year_id, language):
 def get_verbose_children(education_group_year):
     result = []
 
-    for group_element_year in education_group_year.children.exclude(link_type=REFERENCE):
+    for group_element_year in education_group_year.children:
         result.append(group_element_year)
         if group_element_year.child_branch:
             result.append(get_verbose_children(group_element_year.child_branch))


### PR DESCRIPTION
…lément du PDF

Référence Jira : OSIS-1925

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
