### PR TITLE
OSIS-2118 fixed duplication of LearningComponents when extending a LearningUnitYear

### DIFF
--- a/base/business/learning_units/edition.py
+++ b/base/business/learning_units/edition.py
@@ -216,8 +216,6 @@ def _duplicate_learning_unit_component(new_component, new_learn_unit_year):
                                                               a_learning_unit_year=new_learn_unit_year.copied_from):
         new_luc = update_related_object(old_learn_unit_comp, 'learning_unit_year', new_learn_unit_year)
         new_luc.learning_component_year = new_component
-        if not new_luc.learning_unit_year or not new_luc.learning_component_year:
-            print('ERROR')
         new_luc.save()
 
 

--- a/base/business/learning_units/edition.py
+++ b/base/business/learning_units/edition.py
@@ -185,7 +185,8 @@ def _duplicate_entity_container_year(new_lcy, new_academic_year):
 
 
 def _duplicate_learning_component_year(new_learn_container_year, new_learn_unit_year, old_learn_unit_year):
-    old_learning_unit_components = learning_unit_component.find_by_learning_unit_year(old_learn_unit_year).select_related('learning_component_year')
+    old_learning_unit_components = learning_unit_component.find_by_learning_unit_year(old_learn_unit_year)\
+                                                          .select_related('learning_component_year')
     for learn_unit_component in old_learning_unit_components:
         old_component = learn_unit_component.learning_component_year
         new_component = update_related_object(old_component, 'learning_container_year', new_learn_container_year)

--- a/base/business/learning_units/edition.py
+++ b/base/business/learning_units/edition.py
@@ -44,7 +44,6 @@ from base.models.entity_version import EntityVersion
 from base.models.enums import learning_unit_year_periodicity, learning_unit_year_subtypes
 from base.models.enums.entity_container_year_link_type import ENTITY_TYPE_LIST
 from base.models.learning_container_year import LearningContainerYear
-from base.models.learning_unit_component import LearningUnitComponent
 from base.models.learning_unit_year import LearningUnitYear
 from base.models.proposal_learning_unit import is_learning_unit_year_in_proposal
 from cms.models import translated_text
@@ -136,16 +135,20 @@ def _update_end_year_field(lu, year):
 def duplicate_learning_unit_year(old_learn_unit_year, new_academic_year):
     duplicated_luy = update_related_object(old_learn_unit_year, 'academic_year', new_academic_year)
     duplicated_luy.attribution_procedure = None
-    duplicated_luy.learning_container_year = _duplicate_learning_container_year(duplicated_luy, new_academic_year)
+    duplicated_luy.learning_container_year = _duplicate_learning_container_year(
+        duplicated_luy,
+        new_academic_year,
+        old_learn_unit_year
+    )
     _duplicate_teaching_material(duplicated_luy)
     _duplicate_cms_data(duplicated_luy)
     duplicated_luy.save()
     return duplicated_luy
 
 
-def _duplicate_learning_container_year(new_learn_unit_year, new_academic_year):
+def _duplicate_learning_container_year(new_learn_unit_year, new_academic_year, old_learn_unit_year):
     duplicated_lcy = _get_or_create_container_year(new_learn_unit_year, new_academic_year)
-    _duplicate_learning_component_year(duplicated_lcy, new_learn_unit_year)
+    _duplicate_learning_component_year(duplicated_lcy, new_learn_unit_year, old_learn_unit_year)
     duplicated_lcy.save()
     return duplicated_lcy
 
@@ -181,14 +184,14 @@ def _duplicate_entity_container_year(new_lcy, new_academic_year):
         update_related_object(entity_container_y, 'learning_container_year', new_lcy)
 
 
-def _duplicate_learning_component_year(new_learn_container_year, new_learn_unit_year):
-    for old_component in learning_component_year.find_by_learning_container_year(new_learn_container_year.copied_from):
-        if not LearningUnitComponent.objects.filter(
-                learning_component_year__type=old_component.type, learning_unit_year=new_learn_unit_year).exists():
-            new_component = update_related_object(old_component, 'learning_container_year', new_learn_container_year)
-            _duplicate_learning_class_year(new_component)
-            _duplicate_learning_unit_component(new_component, new_learn_unit_year)
-            _duplicate_entity_component_year(new_component)
+def _duplicate_learning_component_year(new_learn_container_year, new_learn_unit_year, old_learn_unit_year):
+    old_learning_unit_components = learning_unit_component.find_by_learning_unit_year(old_learn_unit_year).select_related('learning_component_year')
+    for learn_unit_component in old_learning_unit_components:
+        old_component = learn_unit_component.learning_component_year
+        new_component = update_related_object(old_component, 'learning_container_year', new_learn_container_year)
+        _duplicate_learning_class_year(new_component)
+        _duplicate_learning_unit_component(new_component, new_learn_unit_year)
+        _duplicate_entity_component_year(new_component)
 
 
 def _duplicate_entity_component_year(new_component):
@@ -213,6 +216,8 @@ def _duplicate_learning_unit_component(new_component, new_learn_unit_year):
                                                               a_learning_unit_year=new_learn_unit_year.copied_from):
         new_luc = update_related_object(old_learn_unit_comp, 'learning_unit_year', new_learn_unit_year)
         new_luc.learning_component_year = new_component
+        if not new_luc.learning_unit_year or not new_luc.learning_component_year:
+            print('ERROR')
         new_luc.save()
 
 

--- a/base/models/learning_component_year.py
+++ b/base/models/learning_component_year.py
@@ -91,8 +91,7 @@ class LearningComponentYear(SerializableModel):
 
     @property
     def learning_unit_year(self):
-        learn_unit_year = self.learningunitcomponent_set.all().get().select_related('learning_unit_year')
-        return learn_unit_year.learning_unit_year
+        return self.learningunitcomponent_set.all().select_related('learning_unit_year').get().learning_unit_year
 
     @property
     def real_classes(self):

--- a/base/models/learning_component_year.py
+++ b/base/models/learning_component_year.py
@@ -34,7 +34,7 @@ from osis_common.models.serializable_model import SerializableModel, Serializabl
 
 
 class LearningComponentYearAdmin(SerializableModelAdmin):
-    list_display = ('learning_container_year', 'acronym', 'type', 'comment')
+    list_display = ('learning_container_year', 'learning_unit_year',  'acronym', 'type', 'comment', 'changed')
     search_fields = ['acronym', 'learning_container_year__acronym']
     list_filter = ('learning_container_year__academic_year',)
 
@@ -88,6 +88,11 @@ class LearningComponentYear(SerializableModel):
             return '{}/PM'.format(learning_unit_acronym)
         else:
             return '{}/{}'.format(learning_unit_acronym, self.acronym)
+
+    @property
+    def learning_unit_year(self):
+        learn_unit_year = self.learningunitcomponent_set.all().get().select_related('learning_unit_year')
+        return learn_unit_year.learning_unit_year
 
     @property
     def real_classes(self):


### PR DESCRIPTION
Référence Jira : OSIS-2118

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
