### PR TITLE
IUFC - Add continuing_education_managers to groups

### DIFF
--- a/base/fixtures/groups.json
+++ b/base/fixtures/groups.json
@@ -3386,5 +3386,23 @@
                 ]
             ]
         }
+    },
+    {
+        "model": "auth.group",
+        "fields": {
+            "name": "continuing_education_managers",
+            "permissions": [
+                [
+                    "can_access_admission",
+                    "continuing_education",
+                    "admission"
+                ],
+                [
+                    "change_admission",
+                    "continuing_education",
+                    "admission"
+                ]
+            ]
+        }
     }
 ]


### PR DESCRIPTION
Référence Jira : IUFC-151

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
