### PR TITLE
OSIS-2622 remplacer le champ "Validité" par "Début"

### DIFF
--- a/base/forms/education_group/training.py
+++ b/base/forms/education_group/training.py
@@ -197,6 +197,9 @@ class TrainingEducationGroupYearForm(EducationGroupYearModelForm):
         if not getattr(self.initial, 'academic_year', None):
             self.set_initial_diploma_values()
 
+        if not kwargs['instance']:
+            self.fields['academic_year'].label = _('Start')
+
     def set_initial_diploma_values(self):
         if self.education_group_type and \
                 self.education_group_type.name in TrainingType.with_diploma_values_set_initially_as_true():

--- a/base/forms/education_group/training.py
+++ b/base/forms/education_group/training.py
@@ -197,7 +197,7 @@ class TrainingEducationGroupYearForm(EducationGroupYearModelForm):
         if not getattr(self.initial, 'academic_year', None):
             self.set_initial_diploma_values()
 
-        if not kwargs['instance']:
+        if 'instance' in kwargs and not kwargs['instance']:
             self.fields['academic_year'].label = _('Start')
 
     def set_initial_diploma_values(self):


### PR DESCRIPTION
Pour les gestionnaires facultaires et centraux, remplacer le champ "Validité" par "Début"à l'écran de création d'une formation

Référence Jira : OSIS-2622

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
