### PR TITLE
#OSIS-2703 Dans l'écran de recherche 'Statut des informations pédagog…

### DIFF
--- a/base/templates/learning_unit/summary_list.html
+++ b/base/templates/learning_unit/summary_list.html
@@ -78,7 +78,6 @@
                         <th id="lu_title_sort">{% trans 'Title' %}</th>
                         <th>{% trans 'Type' %}</th>
                         <th>{% trans 'Subtype' %}</th>
-                        <th>{% trans 'Summary responsible(s)' %}</th>
                         <th>{% trans 'Status' %}</th>
                     </tr>
                     </thead>
@@ -95,14 +94,6 @@
                             </td>
                             <td>
                                 {{ learning_unit.get_subtype_display }}
-                            </td>
-                            <td>{% for responsible in learning_unit.summary_responsibles %}
-                                {% if forloop.counter0 > 0 %}
-                                    ,
-                                {% endif %}
-                                {{ responsible.tutor.person.last_name }}
-                                {{ responsible.tutor.person.first_name|default_if_none:'' }}
-                            {% endfor %}
                             </td>
                             <td>
                                 {% trans 'Modification made' as title_status_true %}


### PR DESCRIPTION
…iques', supprimer la colonne 'Responsable(s) des informations'

Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
