### PR TITLE
Osis 2748 Empêcher la modal de souvrir pour les centrals

### DIFF
--- a/base/templatetags/education_group.py
+++ b/base/templatetags/education_group.py
@@ -36,7 +36,6 @@ from base.business.education_groups.perms import is_eligible_to_delete_education
     is_eligible_to_add_mini_training, is_eligible_to_add_group, is_eligible_to_postpone_education_group, \
     _is_eligible_certificate_aims
 from base.models.academic_year import AcademicYear, current_academic_year
-from base.models.enums.groups import FACULTY_MANAGER_GROUP
 from base.models.utils.utils import get_verbose_field_value
 
 # TODO Use inclusion tags instead

--- a/base/templatetags/education_group.py
+++ b/base/templatetags/education_group.py
@@ -64,8 +64,8 @@ def li_with_deletion_perm(context, url, message, url_id="link_delete"):
 
 @register.inclusion_tag('blocks/button/li_template.html', takes_context=True)
 def li_with_update_perm(context, url, message, url_id="link_update"):
-    if context['education_group_year'].academic_year.year < current_academic_year().year and\
-            context['person'].user.groups.filter(name=FACULTY_MANAGER_GROUP).exists():
+    if context['education_group_year'].academic_year.year < current_academic_year().year and \
+            context['person'].is_faculty_manager:
         return li_with_permission(context, _is_eligible_certificate_aims, url, message, url_id, True)
     return li_with_permission(context, is_eligible_to_change_education_group, url, message, url_id)
 

--- a/base/templatetags/education_group.py
+++ b/base/templatetags/education_group.py
@@ -36,6 +36,7 @@ from base.business.education_groups.perms import is_eligible_to_delete_education
     is_eligible_to_add_mini_training, is_eligible_to_add_group, is_eligible_to_postpone_education_group, \
     _is_eligible_certificate_aims
 from base.models.academic_year import AcademicYear, current_academic_year
+from base.models.enums.groups import FACULTY_MANAGER_GROUP
 from base.models.utils.utils import get_verbose_field_value
 
 # TODO Use inclusion tags instead
@@ -63,7 +64,8 @@ def li_with_deletion_perm(context, url, message, url_id="link_delete"):
 
 @register.inclusion_tag('blocks/button/li_template.html', takes_context=True)
 def li_with_update_perm(context, url, message, url_id="link_update"):
-    if context['education_group_year'].academic_year.year < current_academic_year().year:
+    if context['education_group_year'].academic_year.year < current_academic_year().year and\
+            context['person'].user.groups.filter(name=FACULTY_MANAGER_GROUP).exists():
         return li_with_permission(context, _is_eligible_certificate_aims, url, message, url_id, True)
     return li_with_permission(context, is_eligible_to_change_education_group, url, message, url_id)
 


### PR DESCRIPTION
Référence Jira : OSIS-2748

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
