### PR TITLE
OSIS-3120 "Entité resp. cahier des charges", la liste qui apparait ne…

### DIFF
--- a/base/forms/learning_unit/learning_unit_create.py
+++ b/base/forms/learning_unit/learning_unit_create.py
@@ -231,7 +231,7 @@ class LearningContainerYearModelForm(forms.ModelForm):
             },
             forward=['country_requirement_entity']
         ),
-        queryset=find_additional_requirement_entities_choices(),
+        queryset=find_pedagogical_entities_version(),
         label=_('Requirement entity')
     )
 

--- a/base/models/entity_version.py
+++ b/base/models/entity_version.py
@@ -99,6 +99,7 @@ class EntityVersionAdmin(SerializableModelAdmin):
     search_fields = ['entity__id', 'entity__external_id', 'title', 'acronym', 'entity_type', 'start_date', 'end_date']
     raw_id_fields = ('entity', 'parent')
     readonly_fields = ('find_direct_children', 'count_direct_children', 'find_descendants', 'get_parent_version')
+    list_filter = ['entity_type']
 
 
 class EntityVersionQuerySet(models.QuerySet):

--- a/base/models/organization.py
+++ b/base/models/organization.py
@@ -34,6 +34,7 @@ from osis_common.models.serializable_model import SerializableModel, Serializabl
 class OrganizationAdmin(SerializableModelAdmin):
     list_display = ('name', 'acronym', 'type', 'changed', 'logo_tag')
     search_fields = ['acronym', 'name']
+    list_filter = ['type']
 
 
 class Organization(SerializableModel):

--- a/base/tests/views/test_learning_unit.py
+++ b/base/tests/views/test_learning_unit.py
@@ -53,7 +53,7 @@ from base.forms.learning_unit.learning_unit_create import LearningUnitModelForm
 from base.forms.learning_unit.search_form import LearningUnitYearForm
 from base.forms.learning_unit_specifications import LearningUnitSpecificationsForm, LearningUnitSpecificationsEditForm
 from base.models.academic_year import AcademicYear
-from base.models.enums import entity_container_year_link_type, active_status, education_group_categories, \
+from base.models.enums import active_status, education_group_categories, \
     learning_component_year_type, proposal_type, proposal_state
 from base.models.enums import entity_type
 from base.models.enums import internship_subtypes
@@ -378,7 +378,7 @@ class LearningUnitViewTestCase(TestCase):
         json_response = str(response.content, encoding='utf8')
         results = json.loads(json_response)['results']
         self.assertEqual(results[0]['text'], self.entity_version.verbose_title)
-        self.assertEqual(results[1]['text'], self.entity_version_2.verbose_title)
+        self.assertEqual(results[1]['text'], self.entity_version_3.verbose_title)
 
     def test_entity_requirement_autocomplete_with_q(self):
         self.client.force_login(self.person.user)

--- a/base/views/learning_units/update.py
+++ b/base/views/learning_units/update.py
@@ -220,12 +220,10 @@ class AdditionnalEntity2Autocomplete(EntityAutocomplete):
         return super(AdditionnalEntity2Autocomplete, self).get_queryset()
 
 
-class EntityRequirementAutocomplete(LoginRequiredMixin, autocomplete.Select2QuerySetView):
+class EntityRequirementAutocomplete(EntityAutocomplete):
     def get_queryset(self):
-        qs = find_additional_requirement_entities_choices().filter(entity__in=self.request.user.person.linked_entities)
-        if self.q:
-            qs = qs.filter(Q(title__icontains=self.q) | Q(acronym__icontains=self.q))
-        return qs
+        return super(EntityRequirementAutocomplete, self).get_queryset()\
+            .filter(entity__in=self.request.user.person.linked_entities)
 
     def get_result_label(self, result):
         return format_html(result.verbose_title)


### PR DESCRIPTION
… doit contenir que les entités d'enseignement

Référence Jira : OSIS-3120

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
