### PR TITLE
[QA] OSIS-3242 prevent from updating an EducationGroup before 2019

### DIFF
--- a/base/templatetags/education_group.py
+++ b/base/templatetags/education_group.py
@@ -29,6 +29,7 @@ from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
+from django.conf import settings
 
 from base.business.education_group import can_user_edit_administrative_data
 from base.business.education_groups.perms import is_eligible_to_change_education_group, is_eligible_to_add_training, \
@@ -58,7 +59,7 @@ def li_with_update_perm(context, url, message, url_id="link_update"):
     year = context['education_group_year'].academic_year.year
     is_general_faculty_manager = person.is_faculty_manager and not person.is_faculty_manager_for_ue
     is_education_group_in_past = year <= context['current_academic_year'].year
-    if is_education_group_in_past and is_general_faculty_manager:
+    if is_education_group_in_past and is_general_faculty_manager and year >= settings.YEAR_LIMIT_EDG_MODIFICATION:
         return li_with_permission(context, _is_eligible_certificate_aims, url, message, url_id, True)
     return li_with_permission(context, is_eligible_to_change_education_group, url, message, url_id)
 

--- a/base/views/education_groups/update.py
+++ b/base/views/education_groups/update.py
@@ -26,6 +26,7 @@
 from dal import autocomplete
 from django import forms
 from django.contrib.auth.decorators import login_required
+from django.conf import settings
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -60,8 +61,9 @@ def update_education_group(request, root_id, education_group_year_id):
     # it will be used in the templates.
     education_group_year.root = root_id
 
-    if request.user.groups.filter(name=FACULTY_MANAGER_GROUP).exists() and\
-            education_group_year.academic_year.year <= starting_academic_year().year:
+    year = education_group_year.academic_year.year
+    if request.user.groups.filter(name=FACULTY_MANAGER_GROUP).exists() and \
+            settings.YEAR_LIMIT_EDG_MODIFICATION <= year <= starting_academic_year().year:
         return update_certificate_aims(request, root_id, education_group_year)
 
     # Proctect the view


### PR DESCRIPTION
Référence Jira : OSIS-3242

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
