### PR TITLE
[to qa] OSIS-3240 Trigger save on cms  when learning_achievement saved

### DIFF
--- a/base/tests/views/test_learning_achievement.py
+++ b/base/tests/views/test_learning_achievement.py
@@ -23,11 +23,13 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
+from unittest import mock
 
 from django.contrib.auth.models import Permission
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.test import TestCase, RequestFactory
+from django.urls import reverse
 from waffle.models import Flag
 from waffle.testutils import override_flag
 
@@ -43,6 +45,7 @@ from base.tests.factories.person_entity import PersonEntityFactory
 from base.tests.factories.user import SuperUserFactory
 from base.tests.factories.user import UserFactory
 from base.views.learning_achievement import operation, management, create, create_first
+from cms.tests.factories.text_label import TextLabelFactory
 from reference.models.language import FR_CODE_LANGUAGE
 from reference.tests.factories.language import LanguageFactory
 
@@ -249,6 +252,18 @@ class TestLearningAchievementActions(TestCase):
                                        kwargs={'learning_unit_year_id': self.learning_unit_year.id}) + "{}{}".format(
             HTML_ANCHOR, learning_achievement.id)
         self.assertRedirects(response, expected_redirection, fetch_redirect_response=False)
+
+    @mock.patch("cms.models.translated_text.update_or_create")
+    def test_learning_achievement_save_triggers_cms_save(self, mock_translated_text_update_or_create):
+        learning_achievement = LearningAchievementFactory(learning_unit_year=self.learning_unit_year,
+                                                          language=self.language_fr)
+        TextLabelFactory(label='themes_discussed')
+        self.client.post(reverse('achievement_edit',
+                                 kwargs={'learning_unit_year_id': self.learning_unit_year.id,
+                                         'learning_achievement_id': learning_achievement.id}),
+                         data={'code_name': 'AA1', 'text': 'Text'})
+
+        self.assertTrue(mock_translated_text_update_or_create.called)
 
     def test_learning_achievement_create(self):
         achievement_fr = LearningAchievementFactory(language=self.language_fr,


### PR DESCRIPTION
(cherry picked from commit 9d3b2f22495c1876369964a45bcaab4f39b9ff1f)

Référence Jira : OSIS-3240

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
