### PR TITLE
#OSIS-3297 Lors de la visualisation d'une partim, je ne veux pas voir des warning portant sur les autres partims

### DIFF
--- a/base/models/learning_unit_year.py
+++ b/base/models/learning_unit_year.py
@@ -419,7 +419,12 @@ class LearningUnitYear(SerializableModel, ExtraManagerLearningUnitYear):
         all_components = components_queryset.order_by('acronym') \
             .select_related('learning_unit_year')
         for learning_component_year in all_components:
-            _warnings.extend(learning_component_year.warnings)
+            if self.is_partim():
+                if learning_component_year.learning_unit_year == self\
+                        or self.parent == learning_component_year.learning_unit_year:
+                    _warnings.extend(learning_component_year.warnings)
+            else:
+                _warnings.extend(learning_component_year.warnings)
 
         return _warnings
 

--- a/base/models/learning_unit_year.py
+++ b/base/models/learning_unit_year.py
@@ -419,11 +419,8 @@ class LearningUnitYear(SerializableModel, ExtraManagerLearningUnitYear):
         all_components = components_queryset.order_by('acronym') \
             .select_related('learning_unit_year')
         for learning_component_year in all_components:
-            if self.is_partim():
-                if learning_component_year.learning_unit_year == self\
-                        or self.parent == learning_component_year.learning_unit_year:
-                    _warnings.extend(learning_component_year.warnings)
-            else:
+            if not self.is_partim() or learning_component_year.learning_unit_year == self \
+                    or learning_component_year.learning_unit_year == self.parent:
                 _warnings.extend(learning_component_year.warnings)
 
         return _warnings

--- a/base/tests/models/test_learning_unit_year.py
+++ b/base/tests/models/test_learning_unit_year.py
@@ -51,10 +51,11 @@ from base.tests.factories.education_group_type import GroupEducationGroupTypeFac
 from base.tests.factories.entity import EntityFactory
 from base.tests.factories.external_learning_unit_year import ExternalLearningUnitYearFactory
 from base.tests.factories.group_element_year import GroupElementYearFactory
-from base.tests.factories.learning_component_year import LearningComponentYearFactory
+from base.tests.factories.learning_component_year import LearningComponentYearFactory, LecturingLearningComponentYearFactory
 from base.tests.factories.learning_container_year import LearningContainerYearFactory
 from base.tests.factories.learning_unit import LearningUnitFactory
-from base.tests.factories.learning_unit_year import LearningUnitYearFactory, create_learning_units_year
+from base.tests.factories.learning_unit_year import LearningUnitYearFactory, create_learning_units_year, \
+    LearningUnitYearPartimFactory
 from base.tests.factories.prerequisite_item import PrerequisiteItemFactory
 from base.tests.factories.tutor import TutorFactory
 
@@ -568,7 +569,7 @@ class LearningUnitYearWarningsTest(TestCase):
         self.assertFalse(result)
 
     def test_warning_when_credits_is_not_an_interger(self):
-        """In this test, we ensure that the warning of credits is not interger"""
+        """In this test, we ensure that the warning of credits is not integer"""
         self.luy_full.credits = Decimal(5.5)
         self.luy_full.save()
         expected_result = [
@@ -578,7 +579,7 @@ class LearningUnitYearWarningsTest(TestCase):
         self.assertEqual(result, expected_result)
 
     def test_no_warning_when_credits_is_an_interger(self):
-        """In this test, we ensure that the warning is not displayed when of credits is an interger"""
+        """In this test, we ensure that the warning is not displayed when of credits is an integer"""
         self.luy_full.credits = Decimal(5)
         self.luy_full.save()
         self.assertFalse(self.luy_full._check_credits_is_integer())
@@ -626,6 +627,43 @@ class LearningUnitYearWarningsTest(TestCase):
             self.luy_full._check_learning_component_year_warnings(),
             [excepted_error])
         self.assertIn(excepted_error, self.luy_full._check_learning_component_year_warnings())
+
+    def test_warning_multiple_partims(self):
+        """In this test, we ensure that the warnings of partim_b doesn't show up while viewing partim_a identification information"""
+
+        learning_unit_container_year = LearningContainerYearFactory(
+            academic_year=self.generated_ac_years[0]
+        )
+        LearningUnitYearFactory(
+            acronym="LCHIM1210",
+            learning_container_year=learning_unit_container_year,
+            subtype=learning_unit_year_subtypes.FULL,
+            academic_year=self.generated_ac_years[0]
+        )
+        partim_a_with_warnings = LearningUnitYearFactory(
+            acronym="LCHIM1210A",
+            learning_container_year=learning_unit_container_year,
+            subtype=learning_unit_year_subtypes.PARTIM,
+            academic_year=self.generated_ac_years[0]
+        )
+        LecturingLearningComponentYearFactory(learning_unit_year=partim_a_with_warnings,
+                                              hourly_volume_partial_q1=10,
+                                              hourly_volume_partial_q2=10,
+                                              hourly_volume_total_annual=10)
+        partim_b_with_warnings = LearningUnitYearFactory(
+            acronym="LCHIM1210B",
+            learning_container_year=learning_unit_container_year,
+            subtype=learning_unit_year_subtypes.PARTIM,
+            academic_year=self.generated_ac_years[0]
+        )
+        LecturingLearningComponentYearFactory(learning_unit_year=partim_b_with_warnings,
+                                              hourly_volume_partial_q1=10,
+                                              hourly_volume_partial_q2=10,
+                                              hourly_volume_total_annual=10)
+
+        warning_messages = ''.join(str(e) for e in partim_a_with_warnings._check_learning_component_year_warnings())
+        self.assertIn(partim_a_with_warnings.acronym, warning_messages)
+        self.assertNotIn(partim_b_with_warnings.acronym, warning_messages)
 
 
 class TestQuadriConsistency(TestCase):


### PR DESCRIPTION
Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
