### PR TITLE
#OSIS-3325 Si un groupement a 0 crédit: je ne dois pas voir affiché "0 crédit" à coté du groupement dans le PDF

### DIFF
--- a/base/models/group_element_year.py
+++ b/base/models/group_element_year.py
@@ -216,10 +216,7 @@ class GroupElementYear(OrderedModel):
     @property
     def verbose(self):
         if self.child_branch:
-            return "{} ({} {})".format(
-                self.child.title, self.relative_credits or self.child_branch.credits or 0, _("credits")
-            )
-
+            return self._verbose_credits()
         else:
             components = LearningComponentYear.objects.filter(
                 learning_unit_year=self.child_leaf).annotate(
@@ -289,6 +286,14 @@ class GroupElementYear(OrderedModel):
         if self.child:
             return False
         return True
+
+    def _verbose_credits(self):
+        if self.relative_credits or self.child_branch.credits:
+            return "{} ({} {})".format(
+                self.child.title, self.relative_credits or self.child_branch.credits or 0, _("credits")
+            )
+        else:
+            return "{}".format(self.child.title)
 
 
 def find_learning_unit_formations(objects, parents_as_instances=False, with_parents_of_parents=False):

--- a/base/tests/models/test_group_element_year.py
+++ b/base/tests/models/test_group_element_year.py
@@ -40,6 +40,7 @@ from base.tests.factories.education_group_type import EducationGroupTypeFactory
 from base.tests.factories.education_group_year import EducationGroupYearFactory, GroupFactory, MiniTrainingFactory
 from base.tests.factories.group_element_year import GroupElementYearFactory
 from base.tests.factories.learning_unit_year import LearningUnitYearFactory
+from django.utils.translation import ugettext_lazy as _
 
 
 class TestFindBuildParentListByEducationGroupYearId(TestCase):
@@ -60,10 +61,6 @@ class TestFindBuildParentListByEducationGroupYearId(TestCase):
         GroupElementYearFactory(parent=self.child_branch, child_branch=None, child_leaf=self.child_leaf)
 
     def test_with_filters(self):
-        filters = {
-
-            'parent__education_group_type__category': [education_group_categories.TRAINING]
-        }
         result = group_element_year._build_parent_list_by_education_group_year_id(self.child_leaf.academic_year)
 
         expected_result = {
@@ -479,7 +476,9 @@ class TestFetchGroupElementsBehindHierarchy(TestCase):
                                                   child_leaf=None)
         self.link_2 = GroupElementYearFactory(parent=finality_list, child_branch=formation_master_md, child_leaf=None)
         self.link_3 = GroupElementYearFactory(parent=formation_master_md, child_branch=common_core, child_leaf=None)
-        self.link_4 = GroupElementYearFactory(parent=common_core, child_leaf=LearningUnitYearFactory(), child_branch=None)
+        self.link_4 = GroupElementYearFactory(parent=common_core,
+                                              child_leaf=LearningUnitYearFactory(),
+                                              child_branch=None)
 
     def test_with_one_root_id(self):
         queryset = GroupElementYear.objects.all().select_related(
@@ -576,3 +575,33 @@ class TestLinkTypeGroupElementYear(TestCase):
         link = GroupElementYear(parent=major_list_choice, child_branch=major, link_type=None)
         link._clean_link_type()
         self.assertEqual(link.link_type, LinkTypes.REFERENCE.name)
+
+
+class TestGroupElementYearProperty(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.academic_year = AcademicYearFactory()
+
+    def setUp(self):
+        self.egy = EducationGroupYearFactory(academic_year=self.academic_year,
+                                             title="Title FR",
+                                             credits=15)
+        self.group_element_year = GroupElementYearFactory(parent__academic_year=self.academic_year,
+                                                          child_branch=self.egy,
+                                                          relative_credits=10)
+
+    def test_verbose_credit(self):
+        self.assertEqual(self.group_element_year.verbose, "{} ({} {})".format(
+            self.group_element_year.child.title, self.group_element_year.relative_credits, _("credits")))
+
+        self.group_element_year.relative_credits = None
+        self.group_element_year.save()
+
+        self.assertEqual(self.group_element_year.verbose, "{} ({} {})".format(
+            self.group_element_year.child.title, self.group_element_year.child_branch.credits, _("credits")))
+
+        self.egy.credits = None
+        self.egy.save()
+
+        self.assertEqual(self.group_element_year.verbose, "{}".format(
+            self.group_element_year.child.title))


### PR DESCRIPTION
Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
