### PR TITLE
 OSIS-3299 : Filter double person in attribution of a luy 

### DIFF
--- a/assessments/api/serializers/scores_responsible.py
+++ b/assessments/api/serializers/scores_responsible.py
@@ -23,6 +23,7 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
+
 from rest_framework import serializers
 
 
@@ -36,4 +37,12 @@ class ScoresResponsibleListSerializer(serializers.Serializer):
     acronym = serializers.CharField()
     learning_unit_title = serializers.CharField(source='full_title')
     requirement_entity = serializers.CharField()
-    attributions = AttributionSerializer(source='attribution_set', many=True)
+    attributions = serializers.SerializerMethodField()
+
+    def get_attributions(self, obj):
+        visited = set()
+        attributions_list = [
+            e for e in obj.attribution_set.all()
+            if e.tutor.person_id not in visited and not visited.add(e.tutor.person_id)
+        ]
+        return AttributionSerializer(attributions_list, many=True).data

--- a/assessments/api/serializers/scores_responsible.py
+++ b/assessments/api/serializers/scores_responsible.py
@@ -39,6 +39,8 @@ class ScoresResponsibleListSerializer(serializers.Serializer):
     requirement_entity = serializers.CharField()
     attributions = serializers.SerializerMethodField()
 
+    # FIXME Have to filter attribution to not have same person twice for a luy
+    #  (due to a conception problem in the model)
     def get_attributions(self, obj):
         visited = set()
         attributions_list = [


### PR DESCRIPTION
Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
