### PR TITLE
OSIS-3431 do not show |E| for LU of mobility + test

### DIFF
--- a/base/business/education_groups/group_element_year_tree.py
+++ b/base/business/education_groups/group_element_year_tree.py
@@ -268,6 +268,9 @@ class EducationGroupHierarchy:
         return [element.child_leaf for element in self.to_list(flat=True) if element.child_leaf]
 
     def is_borrowed(self) -> bool:
+        if isinstance(self, NodeLeafJsTree) and getattr(self.learning_unit_year, 'externallearningunityear', None):
+            if self.learning_unit_year.externallearningunityear.mobility:
+                return False
         try:
             if self.cache_entity_parent_root.entity_type not in [SECTOR, FACULTY]:
                 root = get_entity_version_parent_or_itself_from_type(

--- a/base/tests/business/education_groups/test_build_tree.py
+++ b/base/tests/business/education_groups/test_build_tree.py
@@ -502,6 +502,30 @@ class TestBuildTree(TestCase):
         str_expected_borrowed = '|E| {}'.format(acronym)
         self.assertTrue(str_expected_borrowed not in node)
 
+    @override_switch('luy_show_borrowed_classes', active=True)
+    def test_contains_luy_borrowed_mobility(self):
+        acronym = 'XTEST0022'
+        eluy = ExternalLearningUnitYearFactory(learning_unit_year__acronym=acronym,
+                                               learning_unit_year__academic_year=self.academic_year,
+                                               mobility=True,
+                                               co_graduation=False,
+                                               learning_unit_year__learning_container_year__requirement_entity=
+                                               self.BARC.entity,
+                                               learning_unit_year__learning_container_year__allocation_entity=
+                                               self.BARC.entity)
+        luy = LearningUnitYear.objects.get(externallearningunityear=eluy)
+        GroupElementYearFactory(
+            parent=self.group_element_year_2.child_branch,
+            child_branch=None,
+            child_leaf=luy
+        )
+
+        node = json.dumps(EducationGroupHierarchy(self.parent).to_json())
+        str_expected_service = '{}'.format(acronym)
+        str_expected_not_service = '|E| {}'.format(acronym)
+        self.assertTrue(str_expected_service in node)
+        self.assertTrue(str_expected_not_service not in node)
+
     @override_switch('egy_show_borrowed_classes', active=True)
     def test_contains_egy_borrowed(self):
         acronym = 'LTEST0022'


### PR DESCRIPTION
Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
