### PR TITLE
[OSIS-2973] Optimize query execution + show spinner when retrieving data

### DIFF
--- a/base/business/learning_units/xls_comparison.py
+++ b/base/business/learning_units/xls_comparison.py
@@ -278,14 +278,6 @@ def _get_entity_to_display(entity):
     return entity.acronym if entity else EMPTY_VALUE
 
 
-def get_academic_year_of_reference(objects):
-    """ TODO : Has to be improved because it's not optimum if the xls list is created from a search with a
-    criteria : academic_year = 'ALL' """
-    if objects:
-        return _get_academic_year(objects[0])
-    return starting_academic_year()
-
-
 def _get_academic_year(obj):
     if isinstance(obj, LearningUnitYear):
         return obj.academic_year

--- a/base/forms/learning_unit/search/external.py
+++ b/base/forms/learning_unit/search/external.py
@@ -93,7 +93,7 @@ class ExternalLearningUnitFilter(FilterSet):
             ('acronym', 'acronym'),
             ('full_title', 'title'),
             ('status', 'status'),
-            ('campus', 'campus'),
+            ('campus__organization__name', 'campus'),
             ('credits', 'credits'),
         ),
         widget=forms.HiddenInput

--- a/base/static/js/osis_datatable.js
+++ b/base/static/js/osis_datatable.js
@@ -23,11 +23,13 @@ function initializeDataTable(tableId, storageKey, pageNumber, itemsPerPage, ajax
         },
         "info"  : false,
         "searching" : false,
+        'processing': true,
         "language": {
             "oAria": {
-                "sSortAscending":  "{% trans 'activate to sort column ascending'%}",
-                "sSortDescending": "{% trans 'activate to sort column descending'%}"
-            }
+                "sSortAscending":  gettext("activate to sort column ascending"),
+                "sSortDescending": gettext("activate to sort column descending")
+            },
+            'processing': gettext("Loading...")
         }
     });
 }

--- a/base/templates/learning_unit/search/base.html
+++ b/base/templates/learning_unit/search/base.html
@@ -113,7 +113,7 @@
 
         <div style="margin-top:10px;">
 
-            {% if page_obj %}
+            {% if learning_units_count %}
                 <div class="row">
 
                     <div class="col-md-3">

--- a/base/templates/learning_unit/search/base.html
+++ b/base/templates/learning_unit/search/base.html
@@ -215,14 +215,7 @@
                         return '<a href="'+ row['osis_url'] +'">'+ data + '</a>';
                     }
                 },
-                {
-                    "name": "title",
-                    "targets": 2,
-                    "data": "title",
-                    "render": function(data, type, row, meta){
-                        return data["fr"]
-                    }
-                },
+                { "name": "title", "targets": 2, "data": "title"},
                 {"name": "type", "targets": 3,  "data": "type_text"},
                 {"name": "subtype", "targets": 4,  "data": "subtype_text"},
                 {"name": "requirement_entity", "targets": 5, "data": "requirement_entity"},

--- a/base/templates/learning_unit/search/description_fiche.html
+++ b/base/templates/learning_unit/search/description_fiche.html
@@ -111,10 +111,7 @@
                 {
                     "name": "title",
                     "targets": 2,
-                    "data": "title",
-                    "render": function(data, type, row, meta){
-                        return data["fr"]
-                    }
+                    "data": "title"
                 },
                 {"name": "type", "targets": 3,  "data": "type_text"},
                 {"name": "subtype", "targets": 4,  "data": "subtype_text"},

--- a/base/templates/learning_unit/search/description_fiche.html
+++ b/base/templates/learning_unit/search/description_fiche.html
@@ -30,7 +30,7 @@
 
         <div style="margin-top:10px;">
 
-            {% if page_obj %}
+            {% if learning_units_count %}
                 <div class="row">
 
                     <div class="col-md-3">

--- a/base/templates/learning_unit/search/external.html
+++ b/base/templates/learning_unit/search/external.html
@@ -100,10 +100,7 @@
             {
                 "name": "title",
                 "targets": 2,
-                "data": "title",
-                "render": function(data, type, row, meta){
-                    return data["fr"];
-                }
+                "data": "title"
             },
             {
                 "name": "campus",

--- a/base/templates/learning_unit/search/proposal.html
+++ b/base/templates/learning_unit/search/proposal.html
@@ -30,7 +30,7 @@
 {% block panel %}
     {% include "learning_unit/blocks/form/search_form_proposal.html" %}
         <div style="margin-top:10px;">
-            {% if page_obj %}
+            {% if learning_units_count %}
 
             <div class="row">
 

--- a/base/templates/learning_unit/search/proposal.html
+++ b/base/templates/learning_unit/search/proposal.html
@@ -166,10 +166,7 @@
                 {
                     "name": "title",
                     "targets": 4,
-                    "data": "title",
-                    "render": function(data, type, row, meta){
-                        return data["fr"]
-                    }
+                    "data": "title"
                 },
                 {"name": "type", "targets": 5,  "data": "type_text"},
                 {"name": "requirement_entity", "targets": 6, "data": "requirement_entity"},

--- a/base/views/learning_units/search/borrowed.py
+++ b/base/views/learning_units/search/borrowed.py
@@ -57,17 +57,21 @@ class BorrowedLearningUnitSearch(PermissionRequiredMixin, CacheFilterMixin, Sear
         context = super().get_context_data(**kwargs)
 
         starting_ac = starting_academic_year()
+        form = context["filter"].form
+
+        select_comparison_form_academic_year = starting_ac
+        if form.is_valid():
+            select_comparison_form_academic_year = form.cleaned_data["academic_year"] or \
+                                                   select_comparison_form_academic_year
 
         context.update({
-            'form': context['filter'].form,
+            'form': form,
             'learning_units_count': context["paginator"].count,
             'current_academic_year': starting_ac,
             'proposal_academic_year': starting_ac.next(),
             'search_type': self.search_type,
             'page_obj': context["page_obj"],
             'items_per_page': context["paginator"].per_page,
-            "form_comparison": SelectComparisonYears(
-                academic_year=get_academic_year_of_reference(context['object_list'])
-            ),
+            "form_comparison": SelectComparisonYears(academic_year=select_comparison_form_academic_year),
         })
         return context

--- a/base/views/learning_units/search/borrowed.py
+++ b/base/views/learning_units/search/borrowed.py
@@ -26,7 +26,6 @@
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django_filters.views import FilterView
 
-from base.business.learning_units.xls_comparison import get_academic_year_of_reference
 from base.forms.learning_unit.comparison import SelectComparisonYears
 from base.forms.learning_unit.search.borrowed import BorrowedLearningUnitSearch
 from base.models.academic_year import starting_academic_year

--- a/base/views/learning_units/search/common.py
+++ b/base/views/learning_units/search/common.py
@@ -81,7 +81,13 @@ class SearchMixin:
 
     def render_to_response(self, context, **response_kwargs):
         if self.request.is_ajax():
-            serializer = self.serializer_class(context["page_obj"], context={'request': self.request}, many=True)
+            serializer = self.serializer_class(
+                context["page_obj"],
+                context={
+                    'request': self.request,
+                    'language': self.request.LANGUAGE_CODE
+                },
+                many=True)
             return JsonResponse({'object_list': serializer.data})
         return super().render_to_response(context, **response_kwargs)
 

--- a/base/views/learning_units/search/proposal.py
+++ b/base/views/learning_units/search/proposal.py
@@ -49,9 +49,15 @@ class SearchLearningUnitProposal(PermissionRequiredMixin, CacheFilterMixin, Sear
         context = super().get_context_data(**kwargs)
 
         starting_ac = starting_academic_year()
+        form = context["filter"].form
+
+        select_comparison_form_academic_year = starting_ac
+        if form.is_valid():
+            select_comparison_form_academic_year = form.cleaned_data["academic_year"] or \
+                                                   select_comparison_form_academic_year
         user_person = get_object_or_404(Person, user=self.request.user)
         context.update({
-            'form': context['filter'].form,
+            'form': form,
             'form_proposal_state': ProposalStateModelForm(is_faculty_manager=user_person.is_faculty_manager),
             'can_change_proposal_state': user_person.is_faculty_manager or user_person.is_central_manager,
             'learning_units_count': context["paginator"].count,
@@ -60,9 +66,7 @@ class SearchLearningUnitProposal(PermissionRequiredMixin, CacheFilterMixin, Sear
             'search_type': self.search_type,
             'page_obj': context["page_obj"],
             'items_per_page': context["paginator"].per_page,
-            "form_comparison": SelectComparisonYears(
-                academic_year=get_academic_year_of_reference(context['object_list'])
-            ),
+            "form_comparison": SelectComparisonYears(academic_year=select_comparison_form_academic_year),
         })
         return context
 

--- a/base/views/learning_units/search/proposal.py
+++ b/base/views/learning_units/search/proposal.py
@@ -6,7 +6,6 @@ from django.utils.translation import gettext_lazy as _
 from django_filters.views import FilterView
 
 from base.business import learning_unit_proposal as proposal_business
-from base.business.learning_units.xls_comparison import get_academic_year_of_reference
 from base.forms.learning_unit.comparison import SelectComparisonYears
 from base.forms.proposal.learning_unit_proposal import ProposalStateModelForm, \
     ProposalLearningUnitFilter

--- a/base/views/learning_units/search/service_course.py
+++ b/base/views/learning_units/search/service_course.py
@@ -26,7 +26,6 @@
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django_filters.views import FilterView
 
-from base.business.learning_units.xls_comparison import get_academic_year_of_reference
 from base.forms.learning_unit.comparison import SelectComparisonYears
 from base.forms.learning_unit.search.service_course import ServiceCourseFilter
 from base.models.academic_year import starting_academic_year

--- a/base/views/learning_units/search/service_course.py
+++ b/base/views/learning_units/search/service_course.py
@@ -58,17 +58,21 @@ class ServiceCourseSearch(PermissionRequiredMixin, CacheFilterMixin, SearchMixin
         context = super().get_context_data(**kwargs)
 
         starting_ac = starting_academic_year()
+        form = context["filter"].form
+
+        select_comparison_form_academic_year = starting_ac
+        if form.is_valid():
+            select_comparison_form_academic_year = form.cleaned_data["academic_year"] or \
+                                                   select_comparison_form_academic_year
 
         context.update({
-            'form': context['filter'].form,
+            'form': form,
             'learning_units_count': context["paginator"].count,
             'current_academic_year': starting_ac,
             'proposal_academic_year': starting_ac.next(),
             'search_type': self.search_type,
             'page_obj': context["page_obj"],
             'items_per_page': context["paginator"].per_page,
-            "form_comparison": SelectComparisonYears(
-                academic_year=get_academic_year_of_reference(context['object_list'])
-            ),
+            "form_comparison": SelectComparisonYears(academic_year=select_comparison_form_academic_year),
         })
         return context

--- a/base/views/learning_units/search/simple.py
+++ b/base/views/learning_units/search/simple.py
@@ -26,7 +26,6 @@
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django_filters.views import FilterView
 
-from base.business.learning_units.xls_comparison import get_academic_year_of_reference
 from base.forms.learning_unit.comparison import SelectComparisonYears
 from base.forms.learning_unit.search.simple import LearningUnitFilter
 from base.models.academic_year import starting_academic_year

--- a/base/views/learning_units/search/simple.py
+++ b/base/views/learning_units/search/simple.py
@@ -55,17 +55,23 @@ class LearningUnitSearch(PermissionRequiredMixin, CacheFilterMixin, SearchMixin,
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+
         starting_ac = starting_academic_year()
+        form = context["filter"].form
+
+        select_comparison_form_academic_year = starting_ac
+        if form.is_valid():
+            select_comparison_form_academic_year = form.cleaned_data["academic_year"] or \
+                                                   select_comparison_form_academic_year
+
         context.update({
-            'form': context['filter'].form,
+            'form': form,
             'learning_units_count': context["paginator"].count,
             'current_academic_year': starting_ac,
             'proposal_academic_year': starting_ac.next(),
             'search_type': self.search_type,
             'page_obj': context["page_obj"],
             'items_per_page': context["paginator"].per_page,
-            "form_comparison": SelectComparisonYears(
-                academic_year=get_academic_year_of_reference(context['object_list'])
-            ),
+            "form_comparison": SelectComparisonYears(academic_year=select_comparison_form_academic_year),
         })
         return context


### PR DESCRIPTION
- Reduce the time to show the learning unit search pages by removing duplicate queries execution.
- Also, show a "laoding..." message when retrieving the learning units via ajax.
- Fix the sort by campus in external learning unit search.
