### PR TITLE
[hotfix/OSIS-3627 => QA] En tant que gestionnaire facultaire, si l_événement est ouvert et si je suis en préparation de programme (hors gestion journalière), je dois pouvoir modifier le nombre de crédits

### DIFF
--- a/rules_management/fixtures/field_reference.json
+++ b/rules_management/fixtures/field_reference.json
@@ -1933,6 +1933,9 @@
             "groups": [
                 [
                     "central_managers"
+                ],
+                [
+                    "faculty_managers"
                 ]
             ]
         },


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-3627 vers QA