### PR TITLE
OSIS-3413 block modify button to not show modal of certificate aims

### DIFF
--- a/base/business/education_groups/perms.py
+++ b/base/business/education_groups/perms.py
@@ -135,7 +135,13 @@ def _is_eligible_education_group(person, education_group, raise_exception):
 
 
 def _is_eligible_certificate_aims(person, education_group, raise_exception):
-    return check_link_to_management_entity(education_group, person, raise_exception)
+    result = check_link_to_management_entity(education_group, person, raise_exception)
+    if education_group.education_group_type.category != TRAINING:
+        if raise_exception:
+            raise PermissionDenied(_("This education group is not editable during this period.").capitalize())
+        return False
+
+    return result
 
 
 def _is_eligible_to_add_education_group_with_category(person, education_group, category, raise_exception):

--- a/base/tests/business/education_groups/test_perms.py
+++ b/base/tests/business/education_groups/test_perms.py
@@ -30,6 +30,7 @@ from unittest import mock
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase
 
+from base.business.education_groups import perms
 from base.business.education_groups.perms import check_permission, \
     check_authorized_type, is_eligible_to_edit_general_information, is_eligible_to_edit_admission_condition, \
     GeneralInformationPerms, CommonEducationGroupStrategyPerms, AdmissionConditionPerms, \
@@ -42,9 +43,11 @@ from base.tests.factories.academic_calendar import AcademicCalendarFactory, Open
 from base.tests.factories.academic_year import AcademicYearFactory, create_current_academic_year
 from base.tests.factories.authorized_relationship import AuthorizedRelationshipFactory
 from base.tests.factories.education_group_year import EducationGroupYearFactory, \
-    EducationGroupYearCommonBachelorFactory, TrainingFactory
-from base.tests.factories.person import PersonFactory, PersonWithPermissionsFactory, CentralManagerFactory, SICFactory, \
-    FacultyManagerFactory, UEFacultyManagerFactory, AdministrativeManagerFactory
+    EducationGroupYearCommonBachelorFactory, TrainingFactory, MiniTrainingFactory, GroupFactory
+from base.tests.factories.entity_version import EntityVersionFactory
+from base.tests.factories.person import PersonFactory, PersonWithPermissionsFactory, CentralManagerFactory, \
+    SICFactory, FacultyManagerFactory, UEFacultyManagerFactory, AdministrativeManagerFactory
+from base.tests.factories.person_entity import PersonEntityFactory
 from base.tests.factories.user import UserFactory
 
 
@@ -60,6 +63,55 @@ class TestPerms(TestCase):
 
         person_with_right = PersonWithPermissionsFactory("add_educationgroup")
         self.assertTrue(check_permission(person_with_right, "base.add_educationgroup"))
+
+    def test_faculty_manager_modify_certificates_aims(self):
+        today = datetime.date.today()
+        entity_version = EntityVersionFactory()
+        entity = entity_version.entity
+        person = FacultyManagerFactory()
+        PersonEntityFactory(entity=entity, person=person, with_child=True)
+
+        AcademicCalendarFactory(
+            start_date=today + datetime.timedelta(days=1),
+            end_date=today + datetime.timedelta(days=3),
+            academic_year=self.current_academic_year,
+            reference=academic_calendar_type.EDUCATION_GROUP_EDITION,
+        )
+
+        test_cases = (
+            {'edy': MiniTrainingFactory(academic_year=self.current_academic_year,
+                                        management_entity=entity,
+                                        administration_entity=entity),
+             'person': person,
+             'expected_result': False
+             },
+            {'edy': GroupFactory(academic_year=self.current_academic_year,
+                                 management_entity=entity,
+                                 administration_entity=entity),
+             'person': person,
+             'expected_result': False
+             },
+            {'edy': TrainingFactory(academic_year=self.current_academic_year,
+                                    management_entity=entity,
+                                    administration_entity=entity),
+             'person': person,
+             'expected_result': True
+             },
+        )
+
+        for case in test_cases:
+            with self.subTest(msg="{} with raise_exception False".format(case['edy'].education_group_type.category)):
+                self.assertEqual(case['expected_result'], perms._is_eligible_certificate_aims(case['person'],
+                                                                                              case['edy'],
+                                                                                              False))
+
+        for case in test_cases[:-1]:
+            with self.subTest(msg="{} with raise_exception True".format(case['edy'].education_group_type.category)):
+                self.assertRaises(PermissionDenied,
+                                  perms._is_eligible_certificate_aims,
+                                  case['person'],
+                                  case['edy'],
+                                  True)
 
     def test_is_education_group_edit_period_opened_case_period_closed(self):
         today = datetime.date.today()

--- a/base/tests/forms/education_group/test_training.py
+++ b/base/tests/forms/education_group/test_training.py
@@ -214,6 +214,7 @@ class TestPostponementEducationGroupYear(TestCase):
 
         self.education_group_year = TrainingFactory(
             academic_year=create_current_academic_year(),
+            education_group_type__name=education_group_types.TrainingType.BACHELOR,
             management_entity=management_entity_version.entity,
             administration_entity=administration_entity_version.entity,
         )


### PR DESCRIPTION
for mini-trainings and groups

Référence Jira : OSIS-3413

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
