### PR TITLE
[hotfix/OSIS-3368 => DEV] Le groupe _expert_users_ n_est plus utile

### DIFF
--- a/base/fixtures/groups.json
+++ b/base/fixtures/groups.json
@@ -2734,49 +2734,6 @@
 {
     "model": "auth.group",
     "fields": {
-        "name": "expert_users",
-        "permissions": [
-            [
-                "can_access_learningclassyear",
-                "base",
-                "learningclassyear"
-            ],
-            [
-                "can_access_learningunitcomponentyear",
-                "base",
-                "learningcomponentyear"
-            ],
-            [
-                "can_access_learningcontaineryear",
-                "base",
-                "learningcontaineryear"
-            ],
-            [
-                "can_access_learningunit",
-                "base",
-                "learningunit"
-            ],
-            [
-                "can_access_externallearningunityear",
-                "base",
-                "externallearningunityear"
-            ],
-            [
-                "can_access_learningunitcomponentclass",
-                "base",
-                "learningunitcomponentclass"
-            ],
-            [
-                "can_access_catalog",
-                "base",
-                "offer"
-            ]
-        ]
-    }
-},
-{
-    "model": "auth.group",
-    "fields": {
         "name": "assistant_administrators",
         "permissions": [
             [


### PR DESCRIPTION
Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
