### PR TITLE
OSIS-3737 removed 'createDiv' from options in CKEditor config (unused…

### DIFF
--- a/backoffice/settings/base.py
+++ b/backoffice/settings/base.py
@@ -291,7 +291,6 @@ CKEDITOR_CONFIGS = {
             ['Bold', 'Italic', 'Underline'],
             ['NumberedList', 'BulletedList'],
             ['Link', 'Unlink'],
-            ['CreateDiv'],
             {'name': 'insert', 'items': ['Table']},
         ],
         'autoParagraph': False,


### PR DESCRIPTION
…/unecessary)

Référence Jira : OSIS-3737

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
