### PR TITLE
[hotfix/OSIS-3782 => QA] Nettoyer les données cahier des charges / infos pédagogiques + assurer contrainte cohérence des données à la suppression d_une UE

### DIFF
--- a/base/models/education_group_year.py
+++ b/base/models/education_group_year.py
@@ -30,6 +30,8 @@ from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.db import models, connection
 from django.db.models import Count, Min, When, Case, Max
+from django.db.models.signals import post_delete
+from django.dispatch.dispatcher import receiver
 from django.urls import reverse
 from django.utils import translation
 from django.utils.functional import cached_property
@@ -51,6 +53,8 @@ from base.models.utils.utils import get_object_or_none
 from base.models.validation_rule import ValidationRule
 from osis_common.models.serializable_model import SerializableModel, SerializableModelManager, SerializableModelAdmin, \
     SerializableQuerySet
+from cms.models.translated_text import TranslatedText
+from cms.enums.entity_name import OFFER_YEAR
 
 
 class EducationGroupYearAdmin(VersionAdmin, SerializableModelAdmin):
@@ -980,3 +984,8 @@ def _find_with_learning_unit_enrollment_count(learning_unit_year):
     return EducationGroupYear.objects \
         .filter(offerenrollment__learningunitenrollment__learning_unit_year_id=learning_unit_year) \
         .annotate(count_learning_unit_enrollments=Count('offerenrollment__learningunitenrollment')).order_by('acronym')
+
+
+@receiver(post_delete, sender=EducationGroupYear)
+def _educationgroupyear_delete(sender, instance, **kwargs):
+    TranslatedText.objects.filter(entity=OFFER_YEAR, reference=instance.id).delete()

--- a/base/models/learning_unit_year.py
+++ b/base/models/learning_unit_year.py
@@ -29,6 +29,8 @@ from django.core.validators import MinValueValidator, MaxValueValidator, RegexVa
 from django.db import models
 from django.db.models import Q, When, CharField, Value, Case, Subquery, OuterRef
 from django.db.models.functions import Concat
+from django.db.models.signals import post_delete
+from django.dispatch.dispatcher import receiver
 from django.urls import reverse
 from django.utils import translation
 from django.utils.functional import cached_property
@@ -50,6 +52,8 @@ from base.models.enums.learning_unit_year_periodicity import PERIODICITY_TYPES, 
 from base.models.learning_component_year import LearningComponentYear
 from base.models.learning_unit import LEARNING_UNIT_ACRONYM_REGEX_MODEL
 from base.models.prerequisite_item import PrerequisiteItem
+from cms.models.translated_text import TranslatedText
+from cms.enums.entity_name import LEARNING_UNIT_YEAR
 from osis_common.models.serializable_model import SerializableModel, SerializableModelAdmin, SerializableModelManager, \
     SerializableQuerySet
 
@@ -684,3 +688,8 @@ def toggle_summary_locked(learning_unit_year_id):
     luy.summary_locked = not luy.summary_locked
     luy.save()
     return luy
+
+
+@receiver(post_delete, sender=LearningUnitYear)
+def _learningunityear_delete(sender, instance, **kwargs):
+    TranslatedText.objects.filter(entity=LEARNING_UNIT_YEAR, reference=instance.id).delete()

--- a/base/tests/models/test_education_group_year.py
+++ b/base/tests/models/test_education_group_year.py
@@ -44,6 +44,9 @@ from base.tests.factories.learning_unit_enrollment import LearningUnitEnrollment
 from base.tests.factories.learning_unit_year import LearningUnitYearFactory
 from base.tests.factories.offer_enrollment import OfferEnrollmentFactory
 from base.tests.factories.offer_year import OfferYearFactory
+from cms.enums import entity_name
+from cms.tests.factories.translated_text import TranslatedTextFactory
+from cms.models.translated_text import TranslatedText
 
 
 class EducationGroupYearTest(TestCase):
@@ -456,3 +459,23 @@ class EducationGroupYearTypeTest(TestCase):
     def test_type_property(self):
         education_group_year = EducationGroupYearFactory()
         self.assertEqual(education_group_year.type, education_group_year.education_group_type.name)
+
+
+class EducationGroupYearDeleteCms(TestCase):
+    def setUp(self):
+        self.education_group_year = EducationGroupYearFactory()
+        self.translated_text = TranslatedTextFactory(entity=entity_name.OFFER_YEAR,
+                                                     reference=self.education_group_year.id)
+
+        self.education_group_year_no_cms = EducationGroupYearFactory()
+
+    def test_delete_education_group_yr_and_cms(self):
+        egy_id = self.education_group_year.id
+        self.education_group_year.delete()
+        self.assertCountEqual(list(TranslatedText.objects.filter(id=self.translated_text.id)), [])
+        self.assertCountEqual(list(TranslatedText.objects.filter(reference=egy_id)), [])
+
+    def test_delete_education_group_yr_without_cms(self):
+        egy_id = self.education_group_year_no_cms.id
+        self.education_group_year_no_cms.delete()
+        self.assertCountEqual(list(TranslatedText.objects.filter(reference=egy_id)), [])

--- a/base/tests/models/test_learning_unit_year.py
+++ b/base/tests/models/test_learning_unit_year.py
@@ -56,6 +56,9 @@ from base.tests.factories.learning_unit import LearningUnitFactory
 from base.tests.factories.learning_unit_year import LearningUnitYearFactory, create_learning_units_year
 from base.tests.factories.prerequisite_item import PrerequisiteItemFactory
 from base.tests.factories.tutor import TutorFactory
+from cms.enums import entity_name
+from cms.tests.factories.translated_text import TranslatedTextFactory
+from cms.models.translated_text import TranslatedText
 
 
 class LearningUnitYearTest(TestCase):
@@ -1012,3 +1015,23 @@ class ContainerTypeVerboseTest(TestCase):
             luy.get_subtype_display()
         )
         self.assertEqual(result, expected_result)
+
+
+class LearningUnitYearDeleteCms(TestCase):
+    def setUp(self):
+        self.learning_unit_year = LearningUnitYearFactory()
+        self.translated_text = TranslatedTextFactory(entity=entity_name.LEARNING_UNIT_YEAR,
+                                                     reference=self.learning_unit_year.id)
+
+        self.learning_unit_year_no_cms = LearningUnitYearFactory()
+
+    def test_delete_learning_unit_yr_and_cms(self):
+        luy_id = self.learning_unit_year.id
+        self.learning_unit_year.delete()
+        self.assertCountEqual(list(TranslatedText.objects.filter(id=self.translated_text.id)), [])
+        self.assertCountEqual(list(TranslatedText.objects.filter(reference=luy_id)), [])
+
+    def test_delete_learning_unit_yr_without_cms(self):
+        luy_id = self.learning_unit_year_no_cms.id
+        self.learning_unit_year_no_cms.delete()
+        self.assertCountEqual(list(TranslatedText.objects.filter(reference=luy_id)), [])


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-3782 vers QA