### PR TITLE
[improvement/OSIS-3701 => DEV] Afficher les crédits absolus de l_UE à côté des crédits relatifs lorsqu_on attache l_UE à un groupement

### DIFF
--- a/program_management/forms/group_element_year.py
+++ b/program_management/forms/group_element_year.py
@@ -61,6 +61,7 @@ class GroupElementYearForm(forms.ModelForm):
             self.instance.parent = parent
             self.instance.child_leaf = child_leaf
             self.instance.child_branch = child_branch
+            self.initial['relative_credits'] = int(self.instance.child.credits) if self.instance.child else None
 
         if self.instance.parent:
             self._define_fields()

--- a/program_management/templates/group_element_year/group_element_year_comment_inner.html
+++ b/program_management/templates/group_element_year/group_element_year_comment_inner.html
@@ -39,7 +39,9 @@
                 {% if form.link_type %}
                     {% bootstrap_row field_0=form.link_type form_group_class_0="col-md-5" field_1=form.block form_group_class_1="col-md-4" field_2=form.is_mandatory label_2=_('Required') form_group_class_2="col-md-3"%}
                 {% else %}
-                    {% bootstrap_row field_0=form.relative_credits form_group_class_0="col-md-5" field_1=form.block form_group_class_1="col-md-4" field_2=form.is_mandatory label_2=_('Required') form_group_class_2="col-md-3"%}
+                    {% with form.instance.child.credits|floatformat:-2|default_if_none:'-' as absolute_credits %}
+                        {% bootstrap_row label_0=form.relative_credits.label|add:" ("|add:"Abs : "|add:absolute_credits|add:")" field_0=form.relative_credits form_group_class_0="col-md-5" field_1=form.block form_group_class_1="col-md-4" field_2=form.is_mandatory label_2=_('Required') form_group_class_2="col-md-3"%}
+                    {% endwith %}
                 {% endif %}
 
                 {% bootstrap_row field_0=form.comment form_group_class_0="col-md-12" %}

--- a/program_management/tests/forms/test_group_element_year_form.py
+++ b/program_management/tests/forms/test_group_element_year_form.py
@@ -172,3 +172,13 @@ class TestGroupElementYearForm(TestCase):
                  'parent_type': self.parent.education_group_type,
              }]
         )
+
+    def test_initial_value_relative_credits(self):
+        form = GroupElementYearForm(parent=self.parent, child_branch=self.child_branch)
+        self.assertEqual(form.initial['relative_credits'], self.child_branch.credits)
+
+        form = GroupElementYearForm(parent=self.parent, child_leaf=self.child_leaf)
+        self.assertEqual(form.initial['relative_credits'], self.child_leaf.credits)
+
+        form = GroupElementYearForm(parent=self.parent)
+        self.assertEqual(form.initial['relative_credits'], None)


### PR DESCRIPTION
Pull request automatique de improvement/OSIS-3701 vers DEV