### PR TITLE
[hotfix/OSIS-3892 => MASTER] Webservice V3 ne renvoie plus d’information pour les mineures

### DIFF
--- a/webservices/api/views/general_information.py
+++ b/webservices/api/views/general_information.py
@@ -23,6 +23,7 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
+from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from rest_framework import generics
 
@@ -46,7 +47,7 @@ class GeneralInformation(generics.RetrieveAPIView):
                 'educationgrouppublicationcontact_set',
                 'educationgroupachievement_set'
             ),
-            acronym=self.kwargs['acronym'].upper(),
+            Q(acronym__iexact=self.kwargs['acronym']) | Q(partial_acronym__iexact=self.kwargs['acronym']),
             academic_year__year=self.kwargs['year']
         )
         return egy

--- a/webservices/tests/api/views/test_general_information.py
+++ b/webservices/tests/api/views/test_general_information.py
@@ -115,14 +115,14 @@ class GeneralInformationTestCase(APITestCase):
         response = self.client.get(invalid_url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_get_results_based_on_edgy_with_acronym(self):
+    def test_get_results_based_on_egy_with_acronym(self):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         serializer = GeneralInformationSerializer(self.egy, context={'language': self.language})
         self.assertEqual(response.data, serializer.data)
 
-    def test_get_results_based_on_edgy_with_partial_acronym(self):
+    def test_get_results_based_on_egy_with_partial_acronym(self):
         url_partial_acronym = reverse('generalinformations_read', kwargs={
             'acronym': self.egy.partial_acronym,
             'year': self.egy.academic_year.year,

--- a/webservices/tests/api/views/test_general_information.py
+++ b/webservices/tests/api/views/test_general_information.py
@@ -115,8 +115,21 @@ class GeneralInformationTestCase(APITestCase):
         response = self.client.get(invalid_url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_get_results(self):
+    def test_get_results_based_on_edgy_with_acronym(self):
         response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        serializer = GeneralInformationSerializer(self.egy, context={'language': self.language})
+        self.assertEqual(response.data, serializer.data)
+
+    def test_get_results_based_on_edgy_with_partial_acronym(self):
+        url_partial_acronym = reverse('generalinformations_read', kwargs={
+            'acronym': self.egy.partial_acronym,
+            'year': self.egy.academic_year.year,
+            'language': self.language
+        })
+
+        response = self.client.get(url_partial_acronym)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         serializer = GeneralInformationSerializer(self.egy, context={'language': self.language})


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-3892 vers MASTER