### PR TITLE
OSIS-3925 : Modifications/améliorations suite au 'test failed' de la …

### DIFF
--- a/base/business/learning_unit_xls.py
+++ b/base/business/learning_unit_xls.py
@@ -156,7 +156,8 @@ def create_xls_with_parameters(user, learning_units, filters, extra_configuratio
                                                     _get_parameters_configurable_list(learning_units,
                                                                                       titles_part1,
                                                                                       user))
-    ws_data.update({xls_build.WORKSHEETS_DATA: [ws_data.get(xls_build.WORKSHEETS_DATA)[0], _prepare_legend_ws_data()]})
+    ws_data.update({xls_build.WORKSHEETS_DATA: [ws_data.get(xls_build.WORKSHEETS_DATA)[0],
+                                                prepare_proposal_legend_ws_data()]})
     return xls_build.generate_xls(ws_data, filters)
 
 
@@ -185,7 +186,7 @@ def _get_significant_volume(volume):
     return ''
 
 
-def _prepare_legend_ws_data():
+def prepare_proposal_legend_ws_data():
     return {
         xls_build.HEADER_TITLES_KEY: [str(_('Legend'))],
         xls_build.CONTENT_KEY: [

--- a/base/locale/en/LC_MESSAGES/django.po
+++ b/base/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-29 14:45+0100\n"
+"POT-Creation-Date: 2019-12-06 09:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2242,6 +2242,9 @@ msgid "Select a language"
 msgstr ""
 
 msgid "Select action to execute"
+msgstr ""
+
+msgid "Select all"
 msgstr ""
 
 msgid "Select all the messages"

--- a/base/locale/fr_BE/LC_MESSAGES/django.po
+++ b/base/locale/fr_BE/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-29 14:45+0100\n"
+"POT-Creation-Date: 2019-12-06 09:21+0100\n"
 "PO-Revision-Date: 2019-04-15 08:35+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -2322,6 +2322,9 @@ msgstr "Sélectionnez une langue"
 
 msgid "Select action to execute"
 msgstr "Sélectionner l'action à exécuter"
+
+msgid "Select all"
+msgstr "Sélectionner tout"
 
 msgid "Select all the messages"
 msgstr "Sélectionner tous les messages"

--- a/base/templates/education_group/blocks/modal/custom_xls.html
+++ b/base/templates/education_group/blocks/modal/custom_xls.html
@@ -28,21 +28,16 @@
         <div class="modal-content">
             <form role="form" method="POST" name="custom_xls_form" id="custom_xls_form"
                   action="{% url "education_group_learning_units_contains" education_group_year_pk=education_group_year.pk %}">
-
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal">×</button>
-                    <h4>{% trans 'Do you want to export the following informations' %}?</h4>
-                </div>
                 <div class="modal-body">
                     {% csrf_token %}
+                    <label>{% trans 'Do you want to export the following informations' %}?</label>
                     <br>
                     <input type="checkbox" id="chb_select_all_custom"/>
-                    <label>{% trans 'Select/deselect all' %}</label>
-                    <br><br>
-
+                    {% trans 'Select all' %}
+                    <br>
                     {% for field in form_xls_custom %}
                         {{ field }}
-                        <label>{{ field.label }}</label>
+                        {{ field.label }}
                         <br>
                     {% endfor %}
                     <br>

--- a/base/tests/business/test_learning_unit_xls.py
+++ b/base/tests/business/test_learning_unit_xls.py
@@ -36,7 +36,7 @@ from attribution.models.enums.function import Functions
 from attribution.tests.factories.attribution_charge_new import AttributionChargeNewFactory
 from attribution.tests.factories.attribution_new import AttributionNewFactory
 from base.business.learning_unit_xls import DEFAULT_LEGEND_STYLES, SPACES, PROPOSAL_LINE_STYLES, \
-    _get_significant_volume, _prepare_legend_ws_data, _get_wrapped_cells, \
+    _get_significant_volume, prepare_proposal_legend_ws_data, _get_wrapped_cells, \
     _get_colored_rows, _get_attribution_line, _add_training_data, \
     _get_data_part1, _get_parameters_configurable_list, WRAP_TEXT_STYLE, HEADER_PROGRAMS, XLS_DESCRIPTION, \
     _get_data_part2, annotate_qs, learning_unit_titles_part1, prepare_xls_content, _get_attribution_detail, \
@@ -110,8 +110,8 @@ class TestLearningUnitXls(TestCase):
         )
         self.old_academic_year = AcademicYearFactory(year=datetime.date.today().year - 2)
         self.current_academic_year = AcademicYearFactory(year=datetime.date.today().year)
-        generatorContainer = GenerateContainer(self.old_academic_year, self.current_academic_year)
-        self.learning_unit_year_with_entities = generatorContainer.generated_container_years[0].learning_unit_year_full
+        generator_container = GenerateContainer(self.old_academic_year, self.current_academic_year)
+        self.learning_unit_year_with_entities = generator_container.generated_container_years[0].learning_unit_year_full
         entities = [
             EntityVersionFactory(
                 start_date=datetime.datetime(1900, 1, 1),
@@ -271,7 +271,7 @@ class TestLearningUnitXls(TestCase):
             xls_build.STYLED_CELLS:
                 DEFAULT_LEGEND_STYLES
         }
-        self.assertEqual(_prepare_legend_ws_data(), expected)
+        self.assertEqual(prepare_proposal_legend_ws_data(), expected)
 
     def test_add_training_data(self):
         luy_1 = LearningUnitYear.objects.filter(pk=self.learning_unit_yr_1.pk).annotate(

--- a/program_management/business/excel.py
+++ b/program_management/business/excel.py
@@ -37,8 +37,8 @@ from openpyxl.writer.excel import save_virtual_workbook
 
 from attribution.business import attribution_charge_new
 from backoffice.settings.base import LEARNING_UNIT_PORTAL_URL
-from base.business.learning_unit_xls import volume_information, annotate_qs, PROPOSAL_LINE_STYLES
-
+from base.business.learning_unit_xls import volume_information, annotate_qs, PROPOSAL_LINE_STYLES, \
+    prepare_proposal_legend_ws_data
 from base.models.education_group_year import EducationGroupYear
 from base.models.enums.prerequisite_operator import OR, AND
 from base.models.enums.proposal_type import ProposalType
@@ -95,7 +95,7 @@ optional_header_for_required_entity = [_('Req. Entity')]
 optional_header_for_proposition = [_('Proposal type'), _('Proposal status')]
 optional_header_for_credits = [_('Credits')]
 optional_header_for_allocation_entity = [_('Alloc. Ent.')]
-optional_header_for_english_title = [_('English title')]
+optional_header_for_english_title = [_('Title in English')]
 optional_header_for_teacher_list = [_('List of teachers')]
 optional_header_for_periodicity = [_('Periodicity')]
 optional_header_for_active = [_('Active')]
@@ -344,10 +344,11 @@ class EducationGroupYearLearningUnitsIsPrerequisiteOfToExcel:
         self.egy = egy
         self.hierarchy = EducationGroupHierarchy(root=self.egy)
         self.learning_unit_years_parent = {}
+        print('coucou')
         for grp in self.hierarchy.included_group_element_years:
             if not grp.child_leaf:
                 continue
-
+            print(grp.child_leaf.id)
             self.learning_unit_years_parent.setdefault(grp.child_leaf.id, grp)
 
     def get_queryset(self):
@@ -491,12 +492,12 @@ class EducationGroupYearLearningUnitsContainedToExcel:
     def __init__(self, egy: EducationGroupYear, custom_xls_form: CustomXlsForm):
         self.egy = egy
         self.hierarchy = EducationGroupHierarchy(root=self.egy)
-        self.learning_unit_years_parent = {}
+        self.learning_unit_years_parent = []
+
         for grp in self.hierarchy.included_group_element_years:
             if not grp.child_leaf:
                 continue
-
-            self.learning_unit_years_parent.setdefault(grp.child_leaf.id, grp)
+            self.learning_unit_years_parent.append(grp)
         self.custom_xls_form = custom_xls_form
 
     def get_queryset(self):
@@ -521,74 +522,85 @@ class EducationGroupYearLearningUnitsContainedToExcel:
 
 def generate_ue_contained_for_workbook(egy: EducationGroupYear, learning_unit_years_parent,
                                        custom_xls_form: CustomXlsForm):
-    excel_lines = _build_excel_lines_ues(egy, custom_xls_form, learning_unit_years_parent)
-    return _get_workbook_for_custom_xls(excel_lines, custom_xls_form.cleaned_data['proposition'])
+    data = _build_excel_lines_ues(egy, custom_xls_form, learning_unit_years_parent)
+    excel_lines = data.get('content')
+    return _get_workbook_for_custom_xls(excel_lines,
+                                        custom_xls_form.cleaned_data['proposition'],
+                                        data.get('colored_cells', {}))
 
 
 def _build_excel_lines_ues(egy: EducationGroupYear, custom_xls_form: CustomXlsForm, learning_unit_years_parent):
     content = _get_headers(custom_xls_form)
 
     optional_data_needed = _optional_data(custom_xls_form)
+    colored_cells = defaultdict(list)
+    idx = 1
+    # for l in learning_unit_years_parent:
+    #     print(type(l))
+    print(len(learning_unit_years_parent))
+    cpt = 0
+    for gey in learning_unit_years_parent:
+        luy = gey.child_leaf
+        data = _fix_data(gey, luy)
 
-    for k, gey in learning_unit_years_parent.items():
-        if gey.child_leaf:
-            luy = gey.child_leaf
-            data = _fix_data(gey, luy)
+        if optional_data_needed['has_required_entity']:
+            data.append(luy.learning_container_year.requirement_entity)
 
-            if optional_data_needed['has_required_entity']:
-                data.append(luy.learning_container_year.requirement_entity)
+        if optional_data_needed['has_allocation_entity']:
+            data.append(luy.learning_container_year.allocation_entity)
 
-            if optional_data_needed['has_proposition']:
-                proposal = find_by_learning_unit_year(luy)
-                if proposal:
-                    data.append(proposal.get_type_display())
-                    data.append(proposal.get_state_display())
-                else:
-                    data.append('')
-                    data.append('')
+        if optional_data_needed['has_credits']:
+            data.append(luy.credits.normalize() or '-')
+        if optional_data_needed['has_periodicity']:
+            data.append(luy.get_periodicity_display())
 
-            if optional_data_needed['has_credits']:
-                data.append(egy.credits)
+        if optional_data_needed['has_active']:
+            data.append(str.strip(yesno(luy.status)))
 
-            if optional_data_needed['has_allocation_entity']:
-                data.append(luy.learning_container_year.allocation_entity)
+        if optional_data_needed['has_quadrimester']:
+            data.append(luy.get_quadrimester_display() or '')
 
-            if optional_data_needed['has_english_title']:
-                data.append(luy.complete_title_english)
+        if optional_data_needed['has_session_derogation']:
+            data.append(luy.get_session_display() or '')
 
-            if optional_data_needed['has_teacher_list']:
-                data.append(
-                    " ; ".join(
-                        [_get_attribution_line(value.get('person'))
-                         for value in attribution_charge_new.find_attribution_charge_new_by_learning_unit_year_as_dict(
-                            luy
-                        ).values()
-                         ]
-                    )
+        if optional_data_needed['has_volume']:
+            luys = annotate_qs(LearningUnitYear.objects.filter(id=luy.id))
+            data.extend(volume_information(luys[0]))
+
+        if optional_data_needed['has_teacher_list']:
+            data.append(
+                ";".join(
+                    [_get_attribution_line(value.get('person'))
+                     for value in attribution_charge_new.find_attribution_charge_new_by_learning_unit_year_as_dict(
+                        luy
+                    ).values()
+                     ]
                 )
+            )
 
-            if optional_data_needed['has_periodicity']:
-                data.append(luy.get_periodicity_display())
+        if optional_data_needed['has_proposition']:
+            proposal = find_by_learning_unit_year(luy)
+            if proposal:
+                data.append(proposal.get_type_display())
+                data.append(proposal.get_state_display())
+            else:
+                data.append('')
+                data.append('')
 
-            if optional_data_needed['has_active']:
-                data.append(yesno(luy.status))
+        if optional_data_needed['has_english_title']:
+            data.append(luy.complete_title_english)
 
-            if optional_data_needed['has_volume']:
-                luys = annotate_qs(LearningUnitYear.objects.filter(id=luy.id))
-                data.extend(volume_information(luys[0]))
+        if optional_data_needed['has_language']:
+            data.append(luy.language)
 
-            if optional_data_needed['has_quadrimester']:
-                data.append(luy.get_quadrimester_display() or '')
+        content.append(data)
 
-            if optional_data_needed['has_session_derogation']:
-                data.append(luy.get_session_display() or '')
-
-            if optional_data_needed['has_language']:
-                data.append(luy.language)
-
-            content.append(data)
-
-    return content
+        if getattr(luy, "proposallearningunit", None):
+            colored_cells[PROPOSAL_LINE_STYLES.get(luy.proposallearningunit.type)].append(idx)
+        idx += 1
+        cpt += 1
+    colored_cells[Style(font=Font(bold=True))].append(0)
+    return {'content': content, 'colored_cells': colored_cells}
 
 
 def _optional_data(custom_xls_form):
@@ -609,23 +621,23 @@ def _get_headers(custom_xls_form):
     return content
 
 
-def _fix_data(gey, luy):
+def _fix_data(gey: GroupElementYear, luy: LearningUnitYear):
     data = []
     data_fix = FixLineUEContained(acronym=luy.acronym,
-                                  year=luy.academic_year.year,
+                                  year=luy.academic_year,
                                   title=luy.complete_title_i18n,
                                   type=luy.get_container_type_display(),
                                   subtype=luy.get_subtype_display(),
                                   gathering="{} - {}".format(gey.parent.partial_acronym, gey.parent.title),
                                   credits="{} / {}".format(gey.relative_credits or '-', luy.credits.normalize() or '-'),
                                   block=gey.block or '',
-                                  mandatory=yesno(gey.is_mandatory))
+                                  mandatory=str.strip(yesno(gey.is_mandatory)))
     for name in data_fix._fields:
         data.append(getattr(data_fix, name))
     return data
 
 
-def _get_workbook_for_custom_xls(excel_lines, need_proposal_legend):
+def _get_workbook_for_custom_xls(excel_lines, need_proposal_legend, colored_cells):
     workbook = Workbook()
     worksheet_title = _clean_worksheet_title(_("List UE"))
     header, *content = [tuple(line) for line in excel_lines]
@@ -634,27 +646,13 @@ def _get_workbook_for_custom_xls(excel_lines, need_proposal_legend):
         WORKSHEET_TITLE_KEY: worksheet_title,
         HEADER_TITLES_KEY: header,
         CONTENT_KEY: content,
-        STYLED_CELLS: {}
+        STYLED_CELLS: {},
+        COLORED_ROWS: colored_cells,
     }
     _build_worksheet(worksheet_data, workbook, 0)
     if need_proposal_legend:
-        _build_legend_worksheet(workbook)
+        _build_worksheet(prepare_proposal_legend_ws_data(), workbook, 1)
     return workbook
-
-
-def _build_legend_worksheet(workbook):
-    legend_data = _build_legend_sheet()
-    legend_content = legend_data.get(LEGEND_WB_CONTENT, [])
-
-    if legend_content:
-        worksheet_data = {
-            WORKSHEET_TITLE_KEY: _('Legend'),
-            HEADER_TITLES_KEY: [_('Proposal legend')],
-            CONTENT_KEY: legend_content,
-            STYLED_CELLS: {},
-            COLORED_ROWS: legend_data.get(LEGEND_WB_STYLE, []),
-        }
-        _build_worksheet(worksheet_data, workbook, 1)
 
 
 def _build_legend_sheet():
@@ -680,6 +678,6 @@ def _add_optional_titles(custom_xls_form):
 def _get_attribution_line(a_person_teacher):
     return "{} {} {}".format(
         a_person_teacher.last_name.upper() or '',
-        a_person_teacher.first_name or '',
-        a_person_teacher.middle_name or '',
+        a_person_teacher.first_name.strip() or '',
+        a_person_teacher.middle_name.strip() or '',
     )

--- a/program_management/business/excel.py
+++ b/program_management/business/excel.py
@@ -344,11 +344,11 @@ class EducationGroupYearLearningUnitsIsPrerequisiteOfToExcel:
         self.egy = egy
         self.hierarchy = EducationGroupHierarchy(root=self.egy)
         self.learning_unit_years_parent = {}
-        print('coucou')
+
         for grp in self.hierarchy.included_group_element_years:
             if not grp.child_leaf:
                 continue
-            print(grp.child_leaf.id)
+
             self.learning_unit_years_parent.setdefault(grp.child_leaf.id, grp)
 
     def get_queryset(self):
@@ -535,9 +535,6 @@ def _build_excel_lines_ues(egy: EducationGroupYear, custom_xls_form: CustomXlsFo
     optional_data_needed = _optional_data(custom_xls_form)
     colored_cells = defaultdict(list)
     idx = 1
-    # for l in learning_unit_years_parent:
-    #     print(type(l))
-    print(len(learning_unit_years_parent))
     cpt = 0
     for gey in learning_unit_years_parent:
         luy = gey.child_leaf

--- a/program_management/forms/custom_xls.py
+++ b/program_management/forms/custom_xls.py
@@ -29,17 +29,17 @@ from django.utils.translation import gettext_lazy as _
 
 class CustomXlsForm(forms.Form):
 
-    required_entity = forms.BooleanField(required=False, label=_('Req. Entity'))
-    proposition = forms.BooleanField(required=False, label=_('Proposal'))
+    required_entity = forms.BooleanField(required=False, label=_('Requirement entity'))
+    allocation_entity = forms.BooleanField(required=False, label=_('Attribution entity'))
     credits = forms.BooleanField(required=False, label=_('Credits'))
-    allocation_entity = forms.BooleanField(required=False, label=_('Alloc. Ent.'))
-    english_title = forms.BooleanField(required=False, label=_('Title in English'))
-    teacher_list = forms.BooleanField(required=False, label=_('List of teachers'))
     periodicity = forms.BooleanField(required=False, label=_('Periodicity'))
     active = forms.BooleanField(required=False, label=_('Active'))
-    volume = forms.BooleanField(required=False, label=_('Volume'))
     quadrimester = forms.BooleanField(required=False, label=_('Quadrimester'))
     session_derogation = forms.BooleanField(required=False, label=_('Session derogation'))
+    volume = forms.BooleanField(required=False, label=_('Volume'))
+    teacher_list = forms.BooleanField(required=False, label=_('Tutors'))
+    proposition = forms.BooleanField(required=False, label=_('Proposals'))
+    english_title = forms.BooleanField(required=False, label=_('Title in English'))
     language = forms.BooleanField(required=False, label=_('Language'))
 
     def get_optional_data(self):


### PR DESCRIPTION
…US OSIS-3688 listes existantes d'UEs pour une formation

* renommer "Sélectionner/Dé-sélectionner tout" en "Sélectionner tout"
* Modifier le layout de la modal permettant de choisir les informations optionnelles pour que ce soit cohérent avec les autres modal de liste xls
* Ré-ordonner les champs proposés dans la modal
* Corriger pour que tous les titres dans l'xls soient bien en anglais
* strip des colonnes où on a "non" comme valeur
* afficher les lus dans le même ordre que l'arcre
* s'assurer que si une ue apparait plusieurs fois dans l'arbre on la voit bien
* mettre en gras la 1ière ligne des titres dans l'xls
* afficher la bonne valeur dans la colonne crédits. On doit voir luy.credits
* retirer les espaces avant/après ';' dans la liste des enseignants
* Anac doit être affiché comme 2019-20 au lieu de 2019
* Faire pour que l'onglet légende soit le même que dans la liste xls des ues personnalisée
* Afficher les propositions en couleur comme dans la liste xls des ues personnalisée

Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
