### PR TITLE
OSIS-3937 : Modifier les règles de report ,  lors de la consolidation…

### DIFF
--- a/base/business/learning_unit.py
+++ b/base/business/learning_unit.py
@@ -179,7 +179,7 @@ def get_achievements_group_by_language(learning_unit_year):
 
 def get_academic_year_postponement_range(luy):
     end_postponement = academic_year.find_academic_year_by_year(
-        luy.learning_unit.end_year.year
+        luy.learning_unit.end_year.year if luy.learning_unit.end_year else None
     ) if luy.learning_unit else None
     max_postponement_year = compute_max_postponement_year(luy.learning_unit, luy.subtype, end_postponement)
     academic_year_postponement_range = AcademicYear.objects.min_max_years(

--- a/base/business/learning_unit_proposal.py
+++ b/base/business/learning_unit_proposal.py
@@ -367,7 +367,8 @@ def _consolidate_modification_proposal_accepted(proposal):
         entities_to_update = proposal.learning_unit_year.learning_container_year.get_map_entity_by_type()
 
         update_learning_unit_year_with_report(next_luy, fields_to_update_clean, entities_to_update,
-                                              override_postponement_consistency=True)
+                                              override_postponement_consistency=True,
+                                              lu_to_consolidate=proposal.learning_unit_year)
     return {}
 
 

--- a/base/business/learning_units/edition.py
+++ b/base/business/learning_units/edition.py
@@ -25,7 +25,6 @@
 ##############################################################################
 
 from django.db import IntegrityError, transaction, Error
-from django.db.models import F
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
@@ -38,7 +37,7 @@ from base.enums.component_detail import COMPONENT_DETAILS
 from base.models import learning_class_year, academic_year
 from base.models.academic_year import AcademicYear, compute_max_academic_year_adjournment
 from base.models.entity import Entity
-from base.models.enums import learning_unit_year_periodicity, learning_unit_year_subtypes
+from base.models.enums import learning_unit_year_subtypes
 from base.models.enums.component_type import COMPONENT_TYPES
 from base.models.enums.entity_container_year_link_type import ENTITY_TYPE_LIST
 from base.models.learning_container_year import LearningContainerYear
@@ -46,6 +45,18 @@ from base.models.learning_unit_year import LearningUnitYear
 from base.models.proposal_learning_unit import is_learning_unit_year_in_proposal
 from cms.models import translated_text
 from osis_common.utils.numbers import normalize_fraction
+from base.business.learning_units.pedagogy import postpone_teaching_materials
+from base.business.learning_unit import get_academic_year_postponement_range
+from base.forms.learning_unit_specifications import update_future_luy
+from django.conf import settings
+from base.business.learning_unit import CMS_LABEL_SUMMARY, CMS_LABEL_PEDAGOGY_FR_AND_EN, \
+    CMS_LABEL_PEDAGOGY_FR_ONLY, CMS_LABEL_SPECIFICATIONS
+from cms.models.translated_text import TranslatedText
+from cms.models.text_label import TextLabel
+from cms.enums.entity_name import LEARNING_UNIT_YEAR
+from base.forms.learning_achievement import update_future_luy as update_future_luy_achievement
+from base.models.learning_achievement import LearningAchievement
+from reference.models.language import find_by_code
 
 FIELDS_TO_EXCLUDE_WITH_REPORT = ("is_vacant", "type_declaration_vacant", "attribution_procedure")
 
@@ -275,6 +286,7 @@ def get_next_academic_years(learning_unit_to_edit, year):
 def update_learning_unit_year_with_report(luy_to_update, fields_to_update, entities_by_type_to_update, **kwargs):
     with_report = kwargs.get('with_report', True)
     override_postponement_consistency = kwargs.get('override_postponement_consistency', False)
+    lu_to_consolidate = kwargs.get('lu_to_consolidate', None)
 
     conflict_report = {}
     if with_report:
@@ -292,6 +304,38 @@ def update_learning_unit_year_with_report(luy_to_update, fields_to_update, entit
 
     # Show conflict error if exists
     check_postponement_conflict_report_errors(conflict_report)
+
+    if lu_to_consolidate:
+        postpone_teaching_materials(luy_to_update)
+
+        if not luy_to_update.academic_year.is_past:
+            ac_year_postponement_range = get_academic_year_postponement_range(lu_to_consolidate)
+
+            cms_labels = \
+                CMS_LABEL_PEDAGOGY_FR_AND_EN + CMS_LABEL_PEDAGOGY_FR_ONLY + CMS_LABEL_SPECIFICATIONS + CMS_LABEL_SUMMARY
+
+            for label_key in cms_labels:
+                a_text_label = TextLabel.objects.filter(label=label_key).first()
+                for code, label in settings.LANGUAGES:
+                    a_text = TranslatedText.objects.filter(text_label=a_text_label,
+                                                           language=code,
+                                                           entity=LEARNING_UNIT_YEAR,
+                                                           reference=lu_to_consolidate.id).first()
+                    cms = {"language": code,
+                           "text_label": a_text_label,
+                           "text": a_text.text if a_text else None
+                           }
+                    update_future_luy(ac_year_postponement_range, luy_to_update, cms)
+            for code, label in settings.LANGUAGES:
+                language = find_by_code(code[:2].upper())
+                texts = LearningAchievement.objects.filter(
+                    learning_unit_year_id=lu_to_consolidate.id,
+                    language=language)
+                for achievement in texts:
+                    update_future_luy_achievement(ac_year_postponement_range,
+                                                  achievement,
+                                                  achievement.code_name,
+                                                  achievement.code_name)
 
 
 # TODO :: Use LearningUnitPostponementForm to extend/shorten a LearningUnit and remove all this code

--- a/base/business/learning_units/pedagogy.py
+++ b/base/business/learning_units/pedagogy.py
@@ -90,4 +90,5 @@ def update_bibliography_changed_field_in_cms(learning_unit_year):
 
 def is_pedagogy_data_must_be_postponed(learning_unit_year):
     return learning_unit_year.academic_year.year >= academic_year.starting_academic_year().year \
-           and not ProposalLearningUnit.objects.filter(learning_unit_year=learning_unit_year).exists()
+           and not ProposalLearningUnit.objects.\
+        filter(learning_unit_year__learning_unit=learning_unit_year.learning_unit).exists()

--- a/base/forms/learning_unit_specifications.py
+++ b/base/forms/learning_unit_specifications.py
@@ -103,19 +103,24 @@ class LearningUnitSpecificationsEditForm(forms.Form):
             if not self.learning_unit_year.academic_year.is_past and self.postponement:
                 ac_year_postponement_range = get_academic_year_postponement_range(self.learning_unit_year)
                 self.last_postponed_academic_year = ac_year_postponement_range.last()
-                self._update_future_luy(ac_year_postponement_range, self.learning_unit_year)
+                cms = {"language": self.trans_text.language,
+                       "text_label": self.text_label,
+                       "text": self.trans_text.text
+                       }
+                update_future_luy(ac_year_postponement_range, self.learning_unit_year, cms)
 
-    def _update_future_luy(self, ac_year_postponement_range, luy):
-        for ac in ac_year_postponement_range:
-            next_luy, created = LearningUnitYear.objects.get_or_create(
-                academic_year=ac,
-                acronym=luy.acronym,
-                learning_unit=luy.learning_unit
-            )
-            TranslatedText.objects.update_or_create(
-                entity=entity_name.LEARNING_UNIT_YEAR,
-                reference=next_luy.id,
-                language=self.trans_text.language,
-                text_label=self.text_label,
-                defaults={'text': self.trans_text.text}
-            )
+
+def update_future_luy(ac_year_postponement_range, luy, cms):
+    for ac in ac_year_postponement_range:
+        next_luy, created = LearningUnitYear.objects.get_or_create(
+            academic_year=ac,
+            acronym=luy.acronym,
+            learning_unit=luy.learning_unit
+        )
+        TranslatedText.objects.update_or_create(
+            entity=entity_name.LEARNING_UNIT_YEAR,
+            reference=next_luy.id,
+            language=cms.get("language"),
+            text_label=cms.get("text_label"),
+            defaults={'text': cms.get("text")}
+        )

--- a/base/tests/views/learning_units/proposals/test_consolidate.py
+++ b/base/tests/views/learning_units/proposals/test_consolidate.py
@@ -23,22 +23,39 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
+import random
 from unittest import mock
+from unittest.mock import patch
 
 from django.contrib.auth.models import Permission
 from django.http import HttpResponseNotAllowed, HttpResponseForbidden, HttpResponseNotFound
 from django.test import TestCase
+from django.test.utils import override_settings
 from rest_framework.reverse import reverse
 from waffle.testutils import override_flag
 
+from base.business.learning_unit import CMS_LABEL_PEDAGOGY_FR_AND_EN, CMS_LABEL_PEDAGOGY_FR_ONLY, \
+    CMS_LABEL_SPECIFICATIONS, CMS_LABEL_SUMMARY
+from base.business.learning_units.edition import _descriptive_fiche_and_achievements_update
 import base.models as mdl_base
 from base.models.enums import proposal_state, learning_unit_year_subtypes, \
     proposal_type
-from base.tests.factories.academic_year import create_current_academic_year
+from base.tests.factories.academic_year import create_current_academic_year, AcademicYearFactory, get_current_year
 from base.tests.factories.entity_version import EntityVersionFactory
+from base.tests.factories.learning_achievement import LearningAchievementFactory
+from base.tests.factories.learning_unit import LearningUnitFactory
+from base.tests.factories.learning_unit_year import LearningUnitYearFactory
 from base.tests.factories.person import PersonFactory
 from base.tests.factories.person_entity import PersonEntityFactory
 from base.tests.factories.proposal_learning_unit import ProposalLearningUnitFactory
+from cms.models.translated_text import TranslatedText
+from cms.tests.factories.text_label import TextLabelFactory
+from cms.tests.factories.translated_text import TranslatedTextFactory
+from reference.tests.factories.language import LanguageFactory
+
+NEW_TEXT = "new text begins in  {}"
+EN_CODE_LANGUAGE = 'EN'
+FR_CODE_LANGUAGE = 'FR'
 
 
 @override_flag('learning_unit_proposal_delete', active=True)
@@ -124,5 +141,86 @@ class TestConsolidate(TestCase):
             learning_unit_year__learning_container_year__academic_year=self.current_academic_year
         )
         lu_id = creation_proposal.learning_unit_year.learning_unit.id
-        self.client.post("learning_unit_consolidate_proposal", data={"learning_unit_year_id": creation_proposal.learning_unit_year.id}, follow=False)
+        self.client.post("learning_unit_consolidate_proposal",
+                         data={"learning_unit_year_id": creation_proposal.learning_unit_year.id}, follow=False)
         self.assertTrue(mdl_base.learning_unit.LearningUnit.objects.filter(pk=lu_id).exists())
+
+
+class TestConsolidateReportForCmsLearningUnitAchievement(TestCase):
+
+    def setUp(self):
+        self.language_fr = LanguageFactory(code=FR_CODE_LANGUAGE)
+        self.language_en = LanguageFactory(code=EN_CODE_LANGUAGE)
+
+        current_year = get_current_year()
+        self.lu = LearningUnitFactory()
+
+        self.learning_unit_year_in_future = []
+        self.luy_past = []
+
+        year = current_year - 3
+
+        concerned_cms_labels = \
+            CMS_LABEL_PEDAGOGY_FR_AND_EN + CMS_LABEL_PEDAGOGY_FR_ONLY + CMS_LABEL_SPECIFICATIONS + CMS_LABEL_SUMMARY
+
+        self.text_label = TextLabelFactory(label=random.choice(concerned_cms_labels),
+                                           entity='learning_unit_year')
+
+        while year <= current_year + 6:
+            ay = AcademicYearFactory(year=year)
+            luy = LearningUnitYearFactory(learning_unit=self.lu, academic_year=ay,
+                                          acronym='LECON2365')
+
+            self._create_description_fiche_and_specifications_data(current_year, luy, year)
+            year += 1
+
+    @patch('base.business.learning_units.edition._update_descriptive_fiche')
+    def test_descriptive_fiche_and_achievements_no_update_because_is_past(self, mock__update_descriptive_fiche):
+        proposal_in_past = ProposalLearningUnitFactory(
+            state=proposal_state.ProposalState.ACCEPTED.name,
+            learning_unit_year=self.luy_past[0])
+
+        _descriptive_fiche_and_achievements_update(proposal_in_past.learning_unit_year, self.luy_past[1])
+        mock__update_descriptive_fiche.assert_not_called()
+
+    @override_settings(LANGUAGES=[('fr-be', 'French'), ], LANGUAGE_CODE='fr-be')
+    def test_descriptive_fiche_and_achievements_update_and_report(self):
+        proposal = ProposalLearningUnitFactory(
+            state=proposal_state.ProposalState.ACCEPTED.name,
+            learning_unit_year=self.learning_unit_year)
+
+        _descriptive_fiche_and_achievements_update(proposal.learning_unit_year, self.learning_unit_year_in_future[0])
+
+        self._assert_learning_unit_achievement_update(proposal)
+        self._assert_cms_data_update(proposal)
+
+    def _assert_cms_data_update(self, proposal):
+        for learning_unit_yr in self.learning_unit_year_in_future:
+            for t in TranslatedText.objects.filter(reference=learning_unit_yr.id, entity='learning_unit_year',
+                                                   language=self.language_fr, text_label=self.text_label):
+                self.assertEqual(t.text, NEW_TEXT.format(proposal.learning_unit_year.academic_year.year))
+
+    def _assert_learning_unit_achievement_update(self, proposal):
+        for la in mdl_base.learning_achievement.LearningAchievement.objects. \
+                filter(learning_unit_year__learning_unit=proposal.learning_unit_year.learning_unit):
+            if la.learning_unit_year.academic_year.year < self.learning_unit_year.academic_year.year:
+                self.assertEqual(la.text, "old text {}".format(la.learning_unit_year.academic_year.year))
+            else:
+                self.assertEqual(la.text, NEW_TEXT.format(proposal.learning_unit_year.academic_year.year))
+
+    def _create_description_fiche_and_specifications_data(self, current_year, luy, year):
+        a_text = "old text {}".format(year)
+        if year > current_year:
+            self.learning_unit_year_in_future.append(luy)
+        if year < current_year:
+            self.luy_past.append(luy)
+        if year == current_year:
+            self.learning_unit_year = luy
+            a_text = NEW_TEXT.format(current_year)
+        LearningAchievementFactory(learning_unit_year=luy,
+                                   text=a_text,
+                                   code_name="1",
+                                   language=self.language_fr)
+        TranslatedTextFactory(reference=luy.id, entity='learning_unit_year',
+                              language="fr-be", text=a_text,
+                              text_label=self.text_label)


### PR DESCRIPTION
… ==> report des fiches descriptives et du cahier des charges

* S'assurer que le report des fiches descriptives et du cahier des charges soit bien fait lors d'une consolidation
* Eviter le report des des fiches descriptives et du cahier des charges dès qu'il existe une proposition sur une UE (et ce en qq année que ce soit)

Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
