### PR TITLE
[hotfix/OSIS-3968 => DEV] Impossible de valider un formulaire de création des OFs car l_onglet diplome à disparu et un champs présent dedans est obligatoire.

### DIFF
--- a/base/tests/views/education_groups/test_create.py
+++ b/base/tests/views/education_groups/test_create.py
@@ -170,6 +170,8 @@ class TestCreate(TestCase):
                 self.assertIsInstance(form_education_group_year, expected_forms_by_category.get(category))
                 if expected_forms_by_category.get(category) == education_group_categories.TRAINING:
                     self.assertEqual(response.context["form_education_group_year"]["show_diploma_tab"], True)
+                else:
+                    self.assertFalse("show_diploma_tab" in response.context["form_education_group_year"])
 
 
 @override_flag('education_group_create', active=True)

--- a/base/tests/views/education_groups/test_create.py
+++ b/base/tests/views/education_groups/test_create.py
@@ -168,6 +168,8 @@ class TestCreate(TestCase):
                 response = self.client.get(self.urls_without_parent_by_category.get(category))
                 form_education_group_year = response.context["form_education_group_year"]
                 self.assertIsInstance(form_education_group_year, expected_forms_by_category.get(category))
+                if expected_forms_by_category.get(category) == education_group_categories.TRAINING:
+                    self.assertEqual(response.context["form_education_group_year"]["show_diploma_tab"], True)
 
 
 @override_flag('education_group_create', active=True)

--- a/base/views/education_groups/create.py
+++ b/base/views/education_groups/create.py
@@ -128,6 +128,7 @@ def create_education_group(request, category, education_group_type_pk, root_id=N
         data.update(
             {
                 "form_hops": form_education_group_year.hops_form,
+                "show_diploma_tab": form_education_group_year.show_diploma_tab(),
             }
         )
 


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-3968 vers DEV