### PR TITLE
[improvement/OSIS-4019 => DEV] En tant que tous, les compteurs des inscrits à la formation doivent uniquement inclure les états INSCRIT et PROVISOIRE (onglet Utilisation d_une UE)

### DIFF
--- a/base/models/education_group_year.py
+++ b/base/models/education_group_year.py
@@ -48,6 +48,7 @@ from base.models.enums import education_group_categories
 from base.models.enums.constraint_type import CONSTRAINT_TYPE, CREDITS
 from base.models.enums.education_group_types import MiniTrainingType, TrainingType, GroupType
 from base.models.enums.funding_codes import FundingCodes
+from base.models.enums.offer_enrollment_state import SUBSCRIBED, PROVISORY
 from base.models.exceptions import MaximumOneParentAllowedException, ValidationWarning
 from base.models.utils.utils import get_object_or_none
 from base.models.validation_rule import ValidationRule
@@ -961,6 +962,9 @@ def search(**kwargs):
     if kwargs.get("partial_acronym"):
         qs = qs.filter(partial_acronym__icontains=kwargs['partial_acronym'])
 
+    if kwargs.get("enrollment_states"):
+        qs = qs.filter(offerenrollment__enrollment_state__in=kwargs['enrollment_states'])
+
     return qs.select_related('education_group_type', 'academic_year')
 
 
@@ -975,7 +979,8 @@ def find_with_enrollments_count(learning_unit_year):
 
 
 def _count_education_group_enrollments_by_id(education_groups_years):
-    educ_groups = search(id=[educ_group.id for educ_group in education_groups_years]) \
+    educ_groups = search(id=[educ_group.id for educ_group in education_groups_years],
+                         enrollment_states=[SUBSCRIBED, PROVISORY]) \
         .annotate(count_formation_enrollments=Count('offerenrollment')).values('id', 'count_formation_enrollments')
     return {obj['id']: obj['count_formation_enrollments'] for obj in educ_groups}
 

--- a/base/tests/factories/offer_enrollment.py
+++ b/base/tests/factories/offer_enrollment.py
@@ -31,6 +31,7 @@ import factory.fuzzy
 from base.tests.factories.education_group_year import EducationGroupYearFactory
 from base.tests.factories.offer_year import OfferYearFactory
 from base.tests.factories.student import StudentFactory
+from base.models.enums import offer_enrollment_state
 
 
 class OfferEnrollmentFactory(factory.django.DjangoModelFactory):
@@ -38,10 +39,11 @@ class OfferEnrollmentFactory(factory.django.DjangoModelFactory):
         model = "base.OfferEnrollment"
 
     changed = factory.fuzzy.FuzzyNaiveDateTime(datetime.datetime(2016, 1, 1),
-                                          datetime.datetime(2017, 3, 1))
+                                               datetime.datetime(2017, 3, 1))
     date_enrollment = factory.fuzzy.FuzzyNaiveDateTime(datetime.datetime(2016, 1, 1),
-                                                  datetime.datetime(2017, 3, 1))
+                                                       datetime.datetime(2017, 3, 1))
     external_id = factory.fuzzy.FuzzyText(length=10, chars=string.digits)
     offer_year = factory.SubFactory(OfferYearFactory)
     student = factory.SubFactory(StudentFactory)
     education_group_year = factory.SubFactory(EducationGroupYearFactory)
+    enrollment_state = offer_enrollment_state.SUBSCRIBED


### PR DESCRIPTION
…vent uniquement inclure les états INSCRIT et PROVISOIRE (onglet Utilisation d'une UE)

Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
