### PR TITLE
OSIS-4095 prevent learning achievement ordering postponement when order is different in future luys

### DIFF
--- a/base/models/abstracts/abstract_achievement.py
+++ b/base/models/abstracts/abstract_achievement.py
@@ -49,5 +49,5 @@ class AbstractAchievement(OrderedModel):
     )
     consistency_id = models.IntegerField(default=1, validators=[MinValueValidator(1)])
 
-    class Meta:
+    class Meta(OrderedModel.Meta):
         abstract = True

--- a/base/models/learning_achievement.py
+++ b/base/models/learning_achievement.py
@@ -23,7 +23,6 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
-from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from reversion.admin import VersionAdmin
@@ -50,7 +49,7 @@ class LearningAchievement(AbstractAchievement):
     )
     order_with_respect_to = ('learning_unit_year', 'language')
 
-    class Meta:
+    class Meta(AbstractAchievement.Meta):
         unique_together = ("consistency_id", "learning_unit_year", "language")
 
     def __str__(self):


### PR DESCRIPTION
Référence Jira : OSIS-4095

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
