### PR TITLE
[feature/OSIS-4188 => DEV] En tant que DAF et délégués, je dois voir le libellé _Formation_ et non _Programme_ dans l_écran de désignation des gestionnaires de parcours

### DIFF
--- a/assessments/templates/admin/pgm_manager.html
+++ b/assessments/templates/admin/pgm_manager.html
@@ -59,7 +59,7 @@
                             </select>
                         </div>
                         <div class="col-md-4">
-                            <label for="slt_offer_type">{% trans 'Program' %}</label>
+                            <label for="slt_offer_type">{% trans 'Training' %}</label>
                             <select class="form-control" id="slt_offer_type" name="offer_type">
                                 <option value="-">{% trans 'All' %}</option>
                                 {% for p in offer_types %}
@@ -117,7 +117,7 @@
                                                 <input type="checkbox" id="chb_pgm_all_id"
                                                        title="{% trans 'Select/deselect all' %}">
                                             </th>
-                                            <th>{% trans 'Program' %}</th>
+                                            <th>{% trans 'Training' %}</th>
                                             <th>{% trans 'Type' %}</th>
                                             <th>{% trans 'Entity' %}</th>
                                         </tr>


### PR DESCRIPTION
Pull request automatique de feature/OSIS-4188 vers DEV