### PR TITLE
improvement/OSIS-3962

### DIFF
--- a/base/static/css/osis.css
+++ b/base/static/css/osis.css
@@ -525,3 +525,13 @@ div.dataTables_wrapper div.dataTables_processing {
     line-height: 15px !important;
     padding-left: 0 !important;
 }
+
+/* Override datatable default style */
+table.dataTable thead .sorting:after, table.dataTable thead .sorting_asc:after, table.dataTable thead .sorting_desc:after, table.dataTable thead .sorting_asc_disabled:after, table.dataTable thead .sorting_desc_disabled:after {
+    position: relative;
+    bottom: 0px;
+    right: 0px;
+    display: inline;
+    vertical-align: middle;
+    margin-left: 5px;
+}


### PR DESCRIPTION
Override du css de datatable pour que les icones de tri soient à coté des titres de colonnes

Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
