### PR TITLE
[hotfix/OSIS-4323 => QA] En tant que DAF et délégués, je dois voir le libellé _Type de formation_ et non _Formation_ dans l_écran de désignation des gestionnaires de parcours

### DIFF
--- a/assessments/templates/admin/pgm_manager.html
+++ b/assessments/templates/admin/pgm_manager.html
@@ -59,7 +59,7 @@
                             </select>
                         </div>
                         <div class="col-md-4">
-                            <label for="slt_offer_type">{% trans 'Training' %}</label>
+                            <label for="slt_offer_type">{% trans 'Type of training' %}</label>
                             <select class="form-control" id="slt_offer_type" name="offer_type">
                                 <option value="-">{% trans 'All' %}</option>
                                 {% for p in offer_types %}


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-4323 vers QA