### PR TITLE
OSIS-4471 Fixer la taille de l'input crédit relatif pour voir sa valeur à chaque fois

### DIFF
--- a/program_management/forms/group_element_year.py
+++ b/program_management/forms/group_element_year.py
@@ -50,7 +50,7 @@ class GroupElementYearForm(forms.ModelForm):
             "comment": forms.Textarea(attrs={'rows': 5}),
             "comment_english": forms.Textarea(attrs={'rows': 5}),
             "block": forms.TextInput(),
-            "relative_credits": forms.TextInput()
+            "relative_credits": forms.TextInput(attrs={'style': 'min-width: 40px;'})
         }
 
     def __init__(self, *args, parent=None, child_branch=None, child_leaf=None, **kwargs):


### PR DESCRIPTION
- Add width sur l'imput des crédits relatifs pour garder une valeur fixe lors de la modification de taille d'écran

Référence Jira : OSIS-4471

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
