### PR TITLE
OSIS-4498 Ajout des tooltips et italic dans les formulaires de creations et editions

### DIFF
--- a/base/templates/learning_unit/blocks/titles.html
+++ b/base/templates/learning_unit/blocks/titles.html
@@ -1,18 +1,41 @@
 {% load bootstrap3 %}
 {% load i18n %}
+{% load learning_unit %}
 
 <div class="panel panel-default">
     <div class="panel-body">
-        <h5><strong><em>{% trans "Title"%} (*)</em></strong></h5>
-        {% bootstrap_field learning_container_year_form.common_title form_group_class="form-group" %}
-        {% bootstrap_field learning_unit_year_form.specific_title form_group_class="form-group" %}
+        <label title="{% trans "The title is made up of the common part and / or any supplement" %}">
+            {% trans "Title" %} *
+        </label>
+        <br>
+        <label style="font-style:italic" title="{% trans "Part of the title which is common to the complete EU, to its partims and to its classes" %}">
+            {% trans "Common part" %}
+        </label>
+        {% bootstrap_field learning_container_year_form.common_title form_group_class="form-group" show_label=False %}
+        {% if learning_unit_year.subtype == "PARTIM" %}
+            <label style="font-style:italic">{% trans "Specific complement (Partim)" %}</label>
+        {% else %}
+            <label style="font-style:italic">{% trans "Specific complement (Full)" %}</label>
+        {% endif %}
+        {% bootstrap_field learning_unit_year_form.specific_title form_group_class="form-group" show_label=False %}
     </div>
 </div>
 <br/>
 <div class="panel panel-default">
     <div class="panel-body">
-        <h5><strong><em>{% trans "Title in English"%}</em></strong></h5>
-        {% bootstrap_field learning_container_year_form.common_title_english form_group_class="form-group" %}
-        {% bootstrap_field learning_unit_year_form.specific_title_english form_group_class="form-group" %}
+        <label title="{% trans "The title is made up of the common part and / or any supplement" %}">
+            {% trans "Title in English" %} *
+        </label>
+        <br>
+        <label style="font-style:italic" title="{% trans "Part of the title which is common to the complete EU, to its partims and to its classes" %}">
+            {% trans "Common part" %}
+        </label>
+        {% bootstrap_field learning_container_year_form.common_title_english form_group_class="form-group" show_label=False %}
+        {% if learning_unit_year.subtype == "PARTIM" %}
+            <label style="font-style:italic">{% trans "Specific complement (Partim)" %}</label>
+        {% else %}
+            <label style="font-style:italic">{% trans "Specific complement (Full)" %}</label>
+        {% endif %}
+        {% bootstrap_field learning_unit_year_form.specific_title_english form_group_class="form-group" show_label=False %}
     </div>
 </div>


### PR DESCRIPTION
- Ajout des tooltips et italic dans les formulaires de creations et editions

Référence Jira : OSIS-4498

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
