### PR TITLE
OSIS-4214 Utilisation de postpoment_form pour vérifier que les éléments devant être créé le sont

### DIFF
--- a/base/forms/learning_unit/edition.py
+++ b/base/forms/learning_unit/edition.py
@@ -28,6 +28,7 @@ from django.utils.translation import gettext_lazy as _
 
 from base.business import event_perms
 from base.business.learning_units.edition import edit_learning_unit_end_date
+from base.forms.learning_unit.learning_unit_postponement import LearningUnitPostponementForm
 from base.forms.utils.choice_field import BLANK_CHOICE_DISPLAY, NO_PLANNED_END_DISPLAY
 from base.models.academic_year import AcademicYear
 
@@ -80,8 +81,19 @@ class LearningUnitEndDateForm(forms.Form):
         return academic_years
 
     def save(self, update_learning_unit_year=True):
-        return edit_learning_unit_end_date(self.learning_unit, self.cleaned_data['academic_year'],
-                                           update_learning_unit_year)
+        postponement_form = LearningUnitPostponementForm(
+            person=self.person,
+            start_postponement=self.learning_unit_year.academic_year,
+            learning_unit_instance=self.learning_unit_year.learning_unit,
+            external=self.learning_unit_year.is_external(),
+        )
+        if postponement_form.is_valid():
+            postponement_form.save()
+        return edit_learning_unit_end_date(
+            self.learning_unit,
+            self.cleaned_data['academic_year'],
+            update_learning_unit_year
+        )
 
 
 class LearningUnitProposalEndDateForm(LearningUnitEndDateForm):

--- a/base/tests/views/test_learning_unit_edition.py
+++ b/base/tests/views/test_learning_unit_edition.py
@@ -113,7 +113,7 @@ class TestLearningUnitEditionView(TestCase, LearningUnitsMixin):
         )
         msg = [m.message for m in get_messages(response.wsgi_request)]
         msg_level = [m.level for m in get_messages(response.wsgi_request)]
-        self.assertEqual(len(msg), 1)
+        self.assertEqual(len(msg), 7)
         self.assertIn(messages.SUCCESS, msg_level)
 
     @mock.patch('base.business.learning_units.perms.is_eligible_for_modification_end_date')

--- a/base/tests/views/test_learning_unit_proposal.py
+++ b/base/tests/views/test_learning_unit_proposal.py
@@ -262,7 +262,7 @@ class TestLearningUnitSuppressionProposal(TestCase):
         AcademicYearFactory.produce(number_past=3, number_future=10)
         cls.person = person_factory.CentralManagerFactory("can_propose_learningunit", "can_access_learningunit")
         an_organization = OrganizationFactory(type=organization_type.MAIN)
-        cls.academic_years = AcademicYearFactory.produce_in_future(quantity=7)
+        cls.academic_years = AcademicYearFactory.produce_in_future(quantity=8)
         cls.current_academic_year = cls.academic_years[0]
         cls.next_academic_year = cls.academic_years[1]
         generate_creation_or_end_date_proposal_calendars(cls.academic_years)
@@ -270,7 +270,7 @@ class TestLearningUnitSuppressionProposal(TestCase):
         an_entity = EntityFactory(organization=an_organization)
         cls.entity_version = EntityVersionFactory(entity=an_entity, entity_type=entity_type.FACULTY,
                                                   start_date=cls.current_academic_year.start_date,
-                                                  end_date=cls.current_academic_year.end_date)
+                                                  end_date=cls.academic_years[7].end_date)
         learning_container_year = LearningContainerYearFactory(
             academic_year=cls.current_academic_year,
             container_type=learning_container_year_types.COURSE,


### PR DESCRIPTION
- Utilisation de postpoment_form pour vérifier que les éléments devant être créé le sont

Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
