### PR TITLE
OSIS-4440 add has_module_perms logic relative to roles

### DIFF
--- a/osis_role/contrib/permissions.py
+++ b/osis_role/contrib/permissions.py
@@ -45,6 +45,15 @@ class ObjectPermissionBackend(ModelBackend):
                 results.add(rule_set.test_rule(perm, user_obj, *args, **kwargs))
         return any(results) or super().has_perm(user_obj, perm, obj=kwargs.get('obj'))
 
+    def has_module_perms(self, user_obj, app_label, *args, **kwargs):
+        if not user_obj.is_active or user_obj.is_anonymous:
+            return False
+        roles_assigned = _get_roles_assigned_to_user(user_obj)
+        all_perms = []
+        for r in roles_assigned:
+            all_perms += [key for key in r.rule_set().keys() if app_label in key]
+        return any(app_label in perm for perm in all_perms)
+
     def _get_group_permissions(self, user_obj, obj=None):
         """
         Override method in order to fallback to default RBAC Django when role is not registered
@@ -80,14 +89,3 @@ def _add_role_queryset_to_perms_context(rule_set, perm, qs):
             return True
         rule_set[perm] = cache_role_qs_fn & rule_set[perm]
     return rule_set
-
-
-# TODO: move this logic into OsisRoleBackend
-def has_module_perms(user_obj, app_label):
-    if not user_obj.is_active or user_obj.is_anonymous:
-        return False
-    roles_assigned = _get_roles_assigned_to_user(user_obj)
-    all_perms = []
-    for r in roles_assigned:
-        all_perms += [key for key in r.rule_set().keys() if app_label in key]
-    return any(app_label in perm for perm in all_perms)

--- a/osis_role/contrib/permissions.py
+++ b/osis_role/contrib/permissions.py
@@ -80,3 +80,14 @@ def _add_role_queryset_to_perms_context(rule_set, perm, qs):
             return True
         rule_set[perm] = cache_role_qs_fn & rule_set[perm]
     return rule_set
+
+
+# TODO: move this logic into OsisRoleBackend
+def has_module_perms(user_obj, app_label):
+    if not user_obj.is_active or user_obj.is_anonymous:
+        return False
+    roles_assigned = _get_roles_assigned_to_user(user_obj)
+    all_perms = []
+    for r in roles_assigned:
+        all_perms += [key for key in r.rule_set().keys() if app_label in key]
+    return any(app_label in perm for perm in all_perms)

--- a/osis_role/contrib/permissions.py
+++ b/osis_role/contrib/permissions.py
@@ -52,7 +52,7 @@ class ObjectPermissionBackend(ModelBackend):
         all_perms = []
         for r in roles_assigned:
             all_perms += [key for key in r.rule_set().keys() if app_label in key]
-        return any(app_label in perm for perm in all_perms)
+        return any(app_label in perm for perm in all_perms) or super().has_module_perms(user_obj, app_label)
 
     def _get_group_permissions(self, user_obj, obj=None):
         """

--- a/osis_role/tests/contrib/test_permissions.py
+++ b/osis_role/tests/contrib/test_permissions.py
@@ -33,7 +33,7 @@ from rules import RuleSet
 
 from base.tests.factories.person import PersonFactory, PersonWithPermissionsFactory
 from base.tests.factories.user import UserFactory
-from osis_role.contrib.permissions import ObjectPermissionBackend, _add_role_queryset_to_perms_context, has_module_perms
+from osis_role.contrib.permissions import ObjectPermissionBackend, _add_role_queryset_to_perms_context
 
 
 class TestObjectPermissionBackend(TestCase):
@@ -125,7 +125,7 @@ class TestHasModulePerms(TestCase):
         self.addCleanup(patcher_role_manager.stop)
 
     def test_user_has_module_perms(self):
-        self.assertTrue(has_module_perms(self.person.user, self.module))
+        self.assertTrue(self.person.user.has_module_perms(self.module))
 
     def test_user_has_not_module_perms(self):
-        self.assertFalse(has_module_perms(self.person.user, 'nonexisting_module'))
+        self.assertFalse(self.person.user.has_module_perms('non_existing_module'))

--- a/osis_role/tests/contrib/test_permissions.py
+++ b/osis_role/tests/contrib/test_permissions.py
@@ -129,3 +129,8 @@ class TestHasModulePerms(TestCase):
 
     def test_user_has_not_module_perms(self):
         self.assertFalse(self.person.user.has_module_perms('non_existing_module'))
+
+    @mock.patch('django.contrib.auth.backends.ModelBackend.has_module_perms')
+    def test_ensure_fallback_to_model_backend_has_module_perms_when_no_relevant_roles(self, mock_has_module_perms):
+        self.person.user.has_module_perms('non_existing_module')
+        self.assertTrue(mock_has_module_perms.called)


### PR DESCRIPTION
Référence Jira : OSIS-4440 (part of this ticket has yet to be done in IUFC)

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
