### PR TITLE
OSIS-4554 Uniformiser les valeurs remark et remark english des UEs externe avec les UEs

### DIFF
--- a/base/templates/learning_unit/identification.html
+++ b/base/templates/learning_unit/identification.html
@@ -180,18 +180,16 @@
                             {% endblock panel_components %}
                         </div>
                     </div>
-                    {% if not object.is_external_with_co_graduation %}
-                        <div class="panel panel-default">
-                            <div class="panel-body">
-                                <div>
-                                    {% dl_tooltip learning_unit_year.learning_unit 'faculty_remark' not_annualized=True %}
-                                </div>
-                                <div>
-                                    {% dl_tooltip learning_unit_year.learning_unit 'other_remark' not_annualized=True %}
-                                </div>
+                    <div class="panel panel-default">
+                        <div class="panel-body">
+                            <div>
+                                {% dl_tooltip learning_unit_year.learning_unit 'faculty_remark' %}
+                            </div>
+                            <div>
+                                {% dl_tooltip learning_unit_year.learning_unit 'other_remark' %}
                             </div>
                         </div>
-                    {% endif %}
+                    </div>
                     {% if learning_unit_year.subtype != "PARTIM" %}
                         <div class="panel panel-default">
                             <div class="panel-body">
@@ -231,8 +229,6 @@
                                     </div>
                                 </div>
                                 {% dl_tooltip learning_unit_year.externallearningunityear 'external_credits' %}
-                                {% dl_tooltip learning_unit_year.learning_unit 'faculty_remark' %}
-                                {% dl_tooltip learning_unit_year.learning_unit 'other_remark' %}
                             </div>
                         </div>
                     {% endif %}


### PR DESCRIPTION
- Enlever l'italique pour les remark et remark_english
- Mettre le tiret quand None
- Uniformiser l'emplacement des remark et remarks_english entre externe et normal

Référence Jira : OSIS-4554 

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
