### PR TITLE
OSIS-4701 init field with pk rather than using to_field_name

### DIFF
--- a/base/forms/education_group/coorganization.py
+++ b/base/forms/education_group/coorganization.py
@@ -39,8 +39,7 @@ from reference.models.country import Country
 class CoorganizationEditForm(PermissionFieldTrainingMixin, forms.ModelForm):
     country = ModelChoiceField(
         queryset=Country.objects.filter(organizationaddress__isnull=False).distinct().order_by('name'),
-        label=_("Country"),
-        to_field_name='name'
+        label=_("Country")
     )
 
     organization = ModelChoiceField(
@@ -80,7 +79,7 @@ class CoorganizationEditForm(PermissionFieldTrainingMixin, forms.ModelForm):
             country = Country.objects.filter(organizationaddress__organization=self.instance.organization).first()
         else:
             country = Country.objects.filter(organizationaddress__isnull=False, iso_code="BE").first()
-        self.fields['country'].initial = country
+        self.fields['country'].initial = country.pk
 
     def check_unique_constraint_between_education_group_year_organization(self):
         qs = EducationGroupOrganization.objects.filter(

--- a/base/tests/forms/education_group/test_coorganization.py
+++ b/base/tests/forms/education_group/test_coorganization.py
@@ -76,7 +76,7 @@ class TestCoorganizationForm(TestCase):
             'form-TOTAL_FORMS': 1,
             'form-INITIAL_FORMS': 0,
             'form-0-diploma': random.choice(DiplomaCoorganizationTypes.get_names()),
-            'form-0-country': self.address.country,
+            'form-0-country': self.address.country.pk,
             'form-0-organization': self.organization_bis.pk
         }
 
@@ -94,7 +94,7 @@ class TestCoorganizationForm(TestCase):
         actual_fields = list(form.fields.keys())
 
         self.assertListEqual(expected_fields, actual_fields)
-        self.assertEqual(form['country'].value(), self.organization_address.country.name)
+        self.assertEqual(form['country'].value(), self.organization_address.country.pk)
         self.assertEqual(form['organization'].value(), self.education_group_organization.organization.pk)
         self.assertEqual(form['diploma'].value(), diploma_coorganization.UNIQUE)
         self.assertTrue(form['all_students'].value())

--- a/base/tests/views/education_groups/test_update.py
+++ b/base/tests/views/education_groups/test_update.py
@@ -70,6 +70,7 @@ from education_group.tests.factories.auth.central_manager import CentralManagerF
 from program_management.business.group_element_years import management
 from program_management.business.group_element_years.attach import AttachEducationGroupYearStrategy
 from program_management.models.enums import node_type
+from reference.tests.factories.country import CountryFactory
 from reference.tests.factories.domain import DomainFactory
 from reference.tests.factories.domain_isced import DomainIscedFactory
 from reference.tests.factories.language import LanguageFactory
@@ -191,6 +192,8 @@ class TestUpdate(TestCase):
             entity=cls.mini_training_education_group_year.management_entity,
             start_date=cls.education_group_year.academic_year.start_date
         )
+        cls.country_be = CountryFactory(iso_code='BE', name='Belgium')
+        cls.organization_address = OrganizationAddressFactory(country=cls.country_be)
 
     def setUp(self):
         self.client.force_login(self.person.user)
@@ -429,7 +432,7 @@ class TestUpdate(TestCase):
             "diploma_printing_title": "Diploma Title",
             'form-TOTAL_FORMS': 1,
             'form-INITIAL_FORMS': 0,
-            'form-0-country': OrganizationAddressFactory(organization=organization, is_main=True).country,
+            'form-0-country': OrganizationAddressFactory(organization=organization, is_main=True).country.pk,
             'form-0-organization': organization.pk,
             'form-0-diploma': diploma_choice,
             'group_element_year_formset-TOTAL_FORMS': 0,
@@ -472,7 +475,7 @@ class TestUpdate(TestCase):
             "diploma_printing_title": "Diploma Title",
             'form-TOTAL_FORMS': 1,
             'form-INITIAL_FORMS': 0,
-            'form-0-country': address.country.pk,
+            'form-0-country': address.country,
             'form-0-organization': organization.pk,
             'form-0-diploma': diploma_choice,
             'group_element_year_formset-TOTAL_FORMS': 0,


### PR DESCRIPTION
Référence Jira : OSIS-4701

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
