### PR TITLE
OSIS-3717 central can add education group/change link data when attached to entity

### DIFF
--- a/base/tests/views/education_groups/test_update.py
+++ b/base/tests/views/education_groups/test_update.py
@@ -30,7 +30,6 @@ from unittest import mock
 
 from django.contrib.auth.models import Permission
 from django.contrib.messages import get_messages
-from django.core.exceptions import ValidationError
 from django.http import HttpResponseForbidden, HttpResponseRedirect, HttpResponse
 from django.test import TestCase
 from django.urls import reverse
@@ -68,7 +67,6 @@ from base.utils.cache import ElementCache
 from base.views.education_groups.update import _get_success_redirect_url, update_education_group
 from education_group.tests.factories.auth.central_manager import CentralManagerFactory
 from program_management.business.group_element_years import management
-from program_management.business.group_element_years.attach import AttachEducationGroupYearStrategy
 from program_management.models.enums import node_type
 from reference.tests.factories.country import CountryFactory
 from reference.tests.factories.domain import DomainFactory
@@ -763,7 +761,6 @@ class TestSelectAttach(TestCase):
             academic_year=cls.academic_year,
             education_group__end_year=cls.next_academic_year_1
         )
-        cls.person = CentralManagerFactory().person
         cls.learning_unit_year = LearningUnitYearFactory(academic_year=cls.academic_year)
         cls.initial_parent_education_group_year = EducationGroupYearFactory(academic_year=cls.academic_year)
         cls.new_parent_education_group_year = EducationGroupYearFactory(
@@ -822,6 +819,8 @@ class TestSelectAttach(TestCase):
             "group_element_year_id": group_above_new_parent.id,
             "action": "attach",
         }
+        cls.person = CentralManagerFactory(entity=cls.new_parent_education_group_year.management_entity).person
+
 
     def setUp(self):
         self.client.force_login(self.person.user)

--- a/education_group/auth/roles/central_manager.py
+++ b/education_group/auth/roles/central_manager.py
@@ -32,20 +32,14 @@ class CentralManager(EducationGroupTypeScopeRoleMixin, osis_role_models.EntityRo
             'base.can_access_catalog': rules.always_allow,  # Perms Backward compibility
             'base.view_educationgroup': rules.always_allow,
             'base.add_training':
-                predicates.is_education_group_year_older_or_equals_than_limit_settings_year &
-                predicates.is_program_edition_period_open &
-                predicates.is_maximum_child_not_reached_for_mini_training_category &
+                predicates.is_maximum_child_not_reached_for_training_category &
                 predicates.is_user_attached_to_management_entity,
             'base.add_minitraining':
-                predicates.is_education_group_year_older_or_equals_than_limit_settings_year &
-                predicates.is_program_edition_period_open &
                 predicates.is_maximum_child_not_reached_for_mini_training_category &
                 predicates.is_user_attached_to_management_entity,
             'base.add_group':
                 predicates.is_not_orphan_group &
-                predicates.is_education_group_year_older_or_equals_than_limit_settings_year &
-                predicates.is_program_edition_period_open &
-                predicates.is_maximum_child_not_reached_for_mini_training_category &
+                predicates.is_maximum_child_not_reached_for_group_category &
                 predicates.is_user_attached_to_management_entity,
             # TODO : split in training, minitraining, group
             'base.change_educationgroup':
@@ -118,8 +112,5 @@ class CentralManager(EducationGroupTypeScopeRoleMixin, osis_role_models.EntityRo
                 predicates.is_education_group_year_older_or_equals_than_limit_settings_year &
                 predicates.is_education_group_type_authorized_according_to_user_scope &
                 predicates.is_user_attached_to_management_entity,
-            'base.change_link_data':
-                predicates.is_education_group_year_older_or_equals_than_limit_settings_year &
-                predicates.is_program_edition_period_open &
-                predicates.is_user_attached_to_management_entity
+            'base.change_link_data': predicates.is_user_attached_to_management_entity,
         })

--- a/education_group/auth/roles/central_manager.py
+++ b/education_group/auth/roles/central_manager.py
@@ -32,12 +32,21 @@ class CentralManager(EducationGroupTypeScopeRoleMixin, osis_role_models.EntityRo
             'base.can_access_catalog': rules.always_allow,  # Perms Backward compibility
             'base.view_educationgroup': rules.always_allow,
             'base.add_training':
-                predicates.is_maximum_child_not_reached_for_training_category,
+                predicates.is_education_group_year_older_or_equals_than_limit_settings_year &
+                predicates.is_program_edition_period_open &
+                predicates.is_maximum_child_not_reached_for_mini_training_category &
+                predicates.is_user_attached_to_management_entity,
             'base.add_minitraining':
-                predicates.is_maximum_child_not_reached_for_mini_training_category,
+                predicates.is_education_group_year_older_or_equals_than_limit_settings_year &
+                predicates.is_program_edition_period_open &
+                predicates.is_maximum_child_not_reached_for_mini_training_category &
+                predicates.is_user_attached_to_management_entity,
             'base.add_group':
                 predicates.is_not_orphan_group &
-                predicates.is_maximum_child_not_reached_for_group_category,
+                predicates.is_education_group_year_older_or_equals_than_limit_settings_year &
+                predicates.is_program_edition_period_open &
+                predicates.is_maximum_child_not_reached_for_mini_training_category &
+                predicates.is_user_attached_to_management_entity,
             # TODO : split in training, minitraining, group
             'base.change_educationgroup':
                 predicates.is_education_group_year_older_or_equals_than_limit_settings_year &
@@ -109,5 +118,8 @@ class CentralManager(EducationGroupTypeScopeRoleMixin, osis_role_models.EntityRo
                 predicates.is_education_group_year_older_or_equals_than_limit_settings_year &
                 predicates.is_education_group_type_authorized_according_to_user_scope &
                 predicates.is_user_attached_to_management_entity,
-            'base.change_link_data': rules.always_allow,
+            'base.change_link_data':
+                predicates.is_education_group_year_older_or_equals_than_limit_settings_year &
+                predicates.is_program_edition_period_open &
+                predicates.is_user_attached_to_management_entity
         })

--- a/program_management/tests/views/prerequisite/test_update.py
+++ b/program_management/tests/views/prerequisite/test_update.py
@@ -34,8 +34,9 @@ from base.tests.factories.academic_year import AcademicYearFactory
 from base.tests.factories.education_group_year import TrainingFactory, GroupFactory, EducationGroupYearBachelorFactory
 from base.tests.factories.group_element_year import GroupElementYearFactory, GroupElementYearChildLeafFactory
 from base.tests.factories.learning_unit_year import LearningUnitYearFakerFactory, LearningUnitYearFactory
-from base.tests.factories.person import PersonFactory, CentralManagerForUEFactory
+from base.tests.factories.person import PersonFactory
 from base.tests.factories.person_entity import PersonEntityFactory
+from education_group.tests.factories.auth.central_manager import CentralManagerFactory
 
 
 class TestUpdateLearningUnitPrerequisite(TestCase):
@@ -52,9 +53,7 @@ class TestUpdateLearningUnitPrerequisite(TestCase):
             child_leaf=cls.learning_unit_year_child,
             child_branch=None
         )
-        cls.person = CentralManagerForUEFactory("change_educationgroup", 'view_educationgroup')
-        PersonEntityFactory(person=cls.person,
-                            entity=cls.education_group_year_parent.management_entity)
+        cls.person = CentralManagerFactory(entity=cls.education_group_year_parent.management_entity).person
 
         cls.url = reverse("learning_unit_prerequisite_update",
                           args=[cls.education_group_year_parent.id, cls.learning_unit_year_child.id])
@@ -70,7 +69,10 @@ class TestUpdateLearningUnitPrerequisite(TestCase):
         self.assertEqual(response.status_code, HttpResponseForbidden.status_code)
 
     def test_not_found_when_learning_unit_not_contained_in_training(self):
-        other_education_group_year = TrainingFactory(academic_year=self.academic_year)
+        other_education_group_year = TrainingFactory(
+            academic_year=self.academic_year,
+            management_entity=self.education_group_year_parent.management_entity
+        )
         url = reverse("learning_unit_prerequisite_update",
                       args=[other_education_group_year.id, self.learning_unit_year_child.id])
         response = self.client.get(url)

--- a/program_management/tests/views/test_groupelementyear_update.py
+++ b/program_management/tests/views/test_groupelementyear_update.py
@@ -35,7 +35,7 @@ from base.tests.factories.academic_year import AcademicYearFactory, get_current_
 from base.tests.factories.authorized_relationship import AuthorizedRelationshipFactory
 from base.tests.factories.education_group_year import EducationGroupYearFactory
 from base.tests.factories.group_element_year import GroupElementYearFactory
-from base.tests.factories.person import CentralManagerForUEFactory
+from education_group.tests.factories.auth.central_manager import CentralManagerFactory
 
 
 @override_flag('education_group_update', active=True)
@@ -55,7 +55,7 @@ class TestEdit(TestCase):
             parent_type=cls.education_group_year.education_group_type,
             child_type=cls.group_element_year.child_branch.education_group_type,
         )
-        cls.person = CentralManagerForUEFactory()
+        cls.person = CentralManagerFactory(entity=cls.education_group_year.management_entity).person
         cls.url = reverse(
             "group_element_year_update",
             kwargs={

--- a/program_management/tests/views/test_perms.py
+++ b/program_management/tests/views/test_perms.py
@@ -54,17 +54,17 @@ class TestCanUpdateGroupElementYear(TestCase):
 
     def test_return_false_when_user_not_linked_to_entity(self):
         person = PersonFactory()
-        self.assertFalse(person.user.has_perm(self.permission_required, self.group_element_year))
+        self.assertFalse(person.user.has_perm(self.permission_required, self.group_element_year.parent))
 
     def test_return_true_if_is_central_manager(self):
         central_manager = CentralManagerFactory(entity=self.group_element_year.parent.management_entity).person
-        self.assertTrue(central_manager.user.has_perm(self.permission_required, self.group_element_year))
+        self.assertTrue(central_manager.user.has_perm(self.permission_required, self.group_element_year.parent))
 
     def test_return_true_if_child_is_learning_unit_and_user_is_central_manager(self):
         GroupElementYearChildLeafFactory(parent=self.group_element_year.parent)
         central_manager = CentralManagerFactory(entity=self.group_element_year.parent.management_entity)
 
-        self.assertTrue(central_manager.person.user.has_perm(self.permission_required, self.group_element_year))
+        self.assertTrue(central_manager.person.user.has_perm(self.permission_required, self.group_element_year.parent))
 
     def test_true_if_person_is_faculty_manager_and_period_open(self):
         OpenAcademicCalendarFactory(reference=EDUCATION_GROUP_EDITION, academic_year=self.current_acy,
@@ -82,7 +82,7 @@ class TestCanUpdateGroupElementYear(TestCase):
 
     def test_raise_permission_denied_if_person_is_program_manager(self):
         program_manager = PersonWithPermissionsFactory(groups=(PROGRAM_MANAGER_GROUP, ))
-        self.assertFalse(program_manager.user.has_perm(self.permission_required, self.group_element_year))
+        self.assertFalse(program_manager.user.has_perm(self.permission_required, self.group_element_year.parent))
 
     def test_true_if_person_has_both_roles(self):
         person_with_both_roles = PersonWithPermissionsFactory(
@@ -91,7 +91,7 @@ class TestCanUpdateGroupElementYear(TestCase):
         )
         CentralManagerFactory(person=person_with_both_roles, entity=self.group_element_year.parent.management_entity)
 
-        self.assertTrue(person_with_both_roles.user.has_perm(self.permission_required, self.group_element_year))
+        self.assertTrue(person_with_both_roles.user.has_perm(self.permission_required, self.group_element_year.parent))
 
     @patch('base.business.event_perms.EventPerm.is_open', return_value=True)
     def test_raise_permission_denied_when_minor_or_major_list_choice_and_person_is_faculty_manager(self, mock_period):

--- a/program_management/tests/views/tree/test_attach.py
+++ b/program_management/tests/views/tree/test_attach.py
@@ -298,7 +298,7 @@ class TestCreateGroupElementYearView(TestCase):
 
         cls.url = reverse("group_element_year_create", args=[cls.egy.id, cls.egy.id])
 
-        cls.person = CentralManagerFactory().person
+        cls.person = CentralManagerFactory(entity=cls.egy.management_entity).person
 
         cls.perm_patcher = mock.patch("base.business.education_groups.perms.is_eligible_to_change_education_group",
                                       return_value=True)
@@ -410,7 +410,7 @@ class TestMoveGroupElementYearView(TestCase):
             args=[cls.root_egy.id, cls.selected_egy.id, cls.group_element_year.id]
         )
 
-        cls.person = CentralManagerFactory().person
+        cls.person = CentralManagerFactory(entity=cls.selected_egy.management_entity).person
 
     def setUp(self):
         self.client.force_login(self.person.user)


### PR DESCRIPTION
Référence Jira : OSIS-3717

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
