### PR TITLE
[QA] OSIS-3784 Vérifier les reports et accès édition journalière dans le passé

### DIFF
--- a/base/tests/views/test_learning_achievement.py
+++ b/base/tests/views/test_learning_achievement.py
@@ -245,7 +245,7 @@ class TestLearningAchievementActions(TestCase):
 
     def test_learning_achievement_simple_save(self):
         msg = self._test_learning_achievement_save()
-        self.assertEqual(msg[0].get('message'), "{}.".format(_("The learning unit has been updated")))
+        self.assertEqual(msg[0].get('message'), "{}".format(_("The learning unit has been updated (without report).")))
         self.assertEqual(msg[0].get('level'), messages.SUCCESS)
 
     def test_learning_achievement_save_with_proposal(self):

--- a/base/tests/views/test_learning_unit_pedagogy.py
+++ b/base/tests/views/test_learning_unit_pedagogy.py
@@ -432,7 +432,7 @@ class LearningUnitPedagogyEditTestCase(TestCase):
         )
         ProposalLearningUnitFactory(learning_unit_year=previous_luy)
         msg = self._post_learning_unit_pedagogy()
-        expected_message = "{}.".format(_("The learning unit has been updated"))
+        expected_message = "{}".format(_("The learning unit has been updated (without report)."))
         self.assertEqual(msg[0].get('message'), expected_message)
         self.assertEqual(msg[0].get('level'), messages.SUCCESS)
 

--- a/base/tests/views/test_learning_unit_pedagogy.py
+++ b/base/tests/views/test_learning_unit_pedagogy.py
@@ -367,7 +367,7 @@ class LearningUnitPedagogyEditTestCase(TestCase):
 
     def test_learning_unit_pedagogy_edit_post(self):
         msg = self._post_learning_unit_pedagogy()
-        self.assertEqual(msg[0].get('message'), "{}.".format(_("The learning unit has been updated")))
+        self.assertEqual(msg[0].get('message'), "{}".format(_("The learning unit has been updated (without report).")))
         self.assertEqual(msg[0].get('level'), messages.SUCCESS)
 
     def test_learning_unit_pedagogy_edit_post_with_postponement(self):

--- a/base/tests/views/test_teaching_material.py
+++ b/base/tests/views/test_teaching_material.py
@@ -91,7 +91,7 @@ class TeachingMaterialCreateTestCase(TestCase):
         mock_is_linked_to_entity_charge.return_value = True
         mock_is_pedagogy_data_must_be_postponed.return_value = False
         msg = self._test_teaching_material_post()
-        self.assertEqual(msg[0].get('message'), "{}.".format(_("The learning unit has been updated")))
+        self.assertEqual(msg[0].get('message'), "{}".format(_("The learning unit has been updated (without report).")))
         self.assertEqual(msg[0].get('level'), messages.SUCCESS)
 
     @mock.patch('base.models.person.Person.is_linked_to_entity_in_charge_of_learning_unit_year')
@@ -126,7 +126,7 @@ class TeachingMaterialCreateTestCase(TestCase):
         mock_is_linked_to_entity_charge.return_value = True
         ProposalLearningUnitFactory(learning_unit_year=self.previous_luy)
         msg = self._test_teaching_material_post()
-        expected_message = "{}.".format(_("The learning unit has been updated"))
+        expected_message = "{}".format(_("The learning unit has been updated (without report)."))
         self.assertEqual(msg[0].get('message'), expected_message)
         self.assertEqual(msg[0].get('level'), messages.SUCCESS)
 

--- a/base/views/learning_unit.py
+++ b/base/views/learning_unit.py
@@ -207,7 +207,7 @@ def build_success_message(last_academic_year=None, learning_unit_year_id=None, w
         )
 
     else:
-        msg = "{}.".format(default_msg)
+        msg = "{}".format(_("The learning unit has been updated (without report)."))
 
     return msg
 

--- a/base/views/learning_unit.py
+++ b/base/views/learning_unit.py
@@ -175,7 +175,7 @@ def _get_cms_label_translated(cms_label, user_language):
 
 
 def build_success_message(last_academic_year=None, learning_unit_year_id=None, with_postponement=False):
-    default_msg = _("The learning unit has been updated")
+    default_msg = _("The learning unit has been updated (without report).")
     luy = LearningUnitYear.objects.get(id=learning_unit_year_id)
     proposal = ProposalLearningUnit.objects.filter(
         learning_unit_year__learning_unit=luy.learning_unit

--- a/base/views/learning_unit.py
+++ b/base/views/learning_unit.py
@@ -175,7 +175,7 @@ def _get_cms_label_translated(cms_label, user_language):
 
 
 def build_success_message(last_academic_year=None, learning_unit_year_id=None, with_postponement=False):
-    default_msg = _("The learning unit has been updated (without report).")
+    default_msg = _("The learning unit has been updated")
     luy = LearningUnitYear.objects.get(id=learning_unit_year_id)
     proposal = ProposalLearningUnit.objects.filter(
         learning_unit_year__learning_unit=luy.learning_unit

--- a/base/views/learning_units/pedagogy/update.py
+++ b/base/views/learning_units/pedagogy/update.py
@@ -110,7 +110,7 @@ def build_success_message(last_luy_reported, luy):
 
     if last_luy_reported and is_pedagogy_data_must_be_postponed(luy):
         msg = "{} {}.".format(
-            default_message,
+            _("The learning unit has been updated"),
             _("and postponed until %(year)s") % {
                 "year": last_luy_reported.academic_year
             }

--- a/base/views/learning_units/pedagogy/update.py
+++ b/base/views/learning_units/pedagogy/update.py
@@ -117,7 +117,7 @@ def build_success_message(last_luy_reported, luy):
         )
     elif proposal and learning_unit.proposal_is_on_same_year(proposal=proposal, base_luy=luy):
         msg = "{}. {}.".format(
-            default_message,
+            _("The learning unit has been updated"),
             _("The learning unit is in proposal, the report from %(proposal_year)s will be done at "
               "consolidation") % {
                 'proposal_year': proposal.learning_unit_year.academic_year
@@ -125,7 +125,7 @@ def build_success_message(last_luy_reported, luy):
         )
     elif proposal and learning_unit.proposal_is_on_future_year(proposal=proposal, base_luy=luy):
         msg = "{} ({}).".format(
-            default_message,
+            _("The learning unit has been updated"),
             _("the report has not been done from %(proposal_year)s because the LU is in proposal") % {
                 'proposal_year': proposal.learning_unit_year.academic_year
             }

--- a/base/views/learning_units/pedagogy/update.py
+++ b/base/views/learning_units/pedagogy/update.py
@@ -131,6 +131,6 @@ def build_success_message(last_luy_reported, luy):
             }
         )
     else:
-        msg = "{}.".format(default_message)
+        msg = "{}".format(default_message)
 
     return msg

--- a/base/views/learning_units/pedagogy/update.py
+++ b/base/views/learning_units/pedagogy/update.py
@@ -105,7 +105,7 @@ def _post_learning_unit_pedagogy_form(request):
 
 
 def build_success_message(last_luy_reported, luy):
-    default_message = _("The learning unit has been updated")
+    default_message = _("The learning unit has been updated (without report).")
     proposal = ProposalLearningUnit.objects.filter(learning_unit_year__learning_unit=luy.learning_unit).first()
 
     if last_luy_reported and is_pedagogy_data_must_be_postponed(luy):


### PR DESCRIPTION
- Modification du message enc as de non report

Référence Jira : OSIS-3784

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
