### PR TITLE
[hotfix/OSIS-4608 => QA] Enlever lastérisque à côté de _Intitulé en anglais_ sur lUE complet et partim, la zone nest pas obligatoire

### DIFF
--- a/base/templates/learning_unit/blocks/titles.html
+++ b/base/templates/learning_unit/blocks/titles.html
@@ -24,7 +24,7 @@
 <div class="panel panel-default">
     <div class="panel-body">
         <label title="{% trans "The title is made up of the common part and / or any supplement" %}">
-            {% trans "Title in English" %} *
+            {% trans "Title in English" %}
         </label>
         <br>
         <label style="font-style:italic" title="{% trans "Part of the title which is common to the complete EU, to its partims and to its classes" %}">


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-4608 vers QA