### PR TITLE
[hotfix/OSIS-4941 => QA] [WS] Le endpoint learning_units ne doit pas contenir les UE externe de mobilité

### DIFF
--- a/learning_unit/api/views/learning_unit.py
+++ b/learning_unit/api/views/learning_unit.py
@@ -23,6 +23,7 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
+from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as filters
 from rest_framework import generics
@@ -48,7 +49,10 @@ class LearningUnitList(LanguageContextSerializerMixin, generics.ListAPIView):
        Return a list of all the learning unit with optional filtering.
     """
     name = 'learningunits_list'
-    queryset = LearningUnitYear.objects.filter(learning_container_year__isnull=False).select_related(
+    queryset = LearningUnitYear.objects.filter(
+        Q(learning_container_year__isnull=False) &
+        (Q(externallearningunityear__mobility=False) | Q(externallearningunityear__isnull=True))
+    ).select_related(
         'academic_year',
         'learning_container_year'
     ).prefetch_related(


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-4941 vers QA