### PR TITLE
OSIS-4926 Correctly set node_type

### DIFF
--- a/program_management/ddd/domain/node.py
+++ b/program_management/ddd/domain/node.py
@@ -23,7 +23,6 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
-import copy
 from _decimal import Decimal
 from collections import OrderedDict
 from typing import List, Set, Dict, Optional
@@ -409,7 +408,7 @@ class NodeGroupYear(Node):
 class NodeLearningUnitYear(Node):
 
     type = NodeType.LEARNING_UNIT
-    node_type = NodeType.LEARNING_UNIT
+    node_type = attr.ib(type=NodeType, default=NodeType.LEARNING_UNIT)
 
     is_prerequisite_of = attr.ib(type=List, factory=list)
     status = attr.ib(type=bool, default=None)


### PR DESCRIPTION
Old way resulted by having node_type = None in instantiated NodeLearningUnitYear

Référence Jira : OSIS-4926

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
