### PR TITLE
OSIS-4964 validate before opening modal when pasting into tree

### DIFF
--- a/program_management/ddd/domain/exception.py
+++ b/program_management/ddd/domain/exception.py
@@ -103,6 +103,8 @@ class CannotCopyTreeDueToEndDate(BusinessException):
 
 # TODO : use BusinessException instead of BusinessExceptions
 class ProgramTreeVersionMismatch(BusinessExceptions):
-    def __init__(self, *args, **kwargs):
-        messages = [_('The child version must be the same as the root node version')]
+    def __init__(self, root_node: 'Node', node_to_add: 'Node', *args, **kwargs):
+        messages = [_("%(node_to_add)s version must be the same as %(root_node)s version") % {
+            'node_to_add': node_to_add, 'root_node': root_node
+        }]
         super().__init__(messages, **kwargs)

--- a/program_management/ddd/validators/_match_version.py
+++ b/program_management/ddd/validators/_match_version.py
@@ -42,4 +42,4 @@ class MatchVersionValidator(business_validator.BusinessValidator):
         self.root_node_version = self.version_search.get_from_node_identity(self.root_node.entity_id)
         self.child_version = self.version_search.get_from_node_identity(self.node_to_add.entity_id)
         if self.node_to_add.is_training() and self.root_node_version.version_name != self.child_version.version_name:
-            raise exception.ProgramTreeVersionMismatch()
+            raise exception.ProgramTreeVersionMismatch(self.root_node, self.node_to_add)

--- a/program_management/locale/en/LC_MESSAGES/django.po
+++ b/program_management/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-18 12:14+0200\n"
+"POT-Creation-Date: 2020-08-21 09:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -24,6 +24,10 @@ msgstr "\"%(child)s\" has been removed from \"%(parent)s\""
 #| msgid "\"%(child)s\" has been detached from \"%(parent)s\""
 msgid "\"%(child)s\" has been pasted into \"%(parent)s\""
 msgstr "\"%(child)s\" has been removed from \"%(parent)s\""
+
+#, python-format
+msgid "%(node_to_add)s version must be the same as %(root_node)s version"
+msgstr ""
 
 #, python-format
 msgid "%(start_index)s to %(end_index)s of %(total_counts)s learning units"

--- a/program_management/locale/fr_BE/LC_MESSAGES/django.po
+++ b/program_management/locale/fr_BE/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-18 12:14+0200\n"
+"POT-Creation-Date: 2020-08-21 09:30+0200\n"
 "PO-Revision-Date: 2019-04-15 08:35+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -25,6 +25,10 @@ msgstr "\"%(child)s\" a été retiré de \"%(parent)s\""
 #, python-format
 msgid "\"%(child)s\" has been pasted into \"%(parent)s\""
 msgstr "\"%(child)s\" a été collé dans \"%(parent)s\""
+
+#, python-format
+msgid "%(node_to_add)s version must be the same as %(root_node)s version"
+msgstr "La version de %(node_to_add)s doit être la même que %(root_node)s."
 
 #, python-format
 msgid "%(start_index)s to %(end_index)s of %(total_counts)s learning units"
@@ -571,9 +575,6 @@ msgid ""
 msgstr ""
 "L'élément %(child)s que vous voulez attachez est déjà un parent de l'élément "
 "auquel vous voulez rattachez."
-
-msgid "The child version must be the same as the root node version"
-msgstr "La version de la formation ajoutée doit être la même que celle du parent."
 
 #, python-format
 msgid "The learning unit %(acronym)s is not contained inside the formation"

--- a/program_management/tests/ddd/validators/test_match_version.py
+++ b/program_management/tests/ddd/validators/test_match_version.py
@@ -63,8 +63,9 @@ class TestMatchVersionValidator(TestValidatorValidateMixin, SimpleTestCase):
             ProgramTreeVersionIdentity(offer_acronym=self.node_to_attach.code, version_name='B', **identity_values)
         ]
         expected_message = _(
-            'The child version must be the same as the root node version'
-        )
+            '%(node_to_add)s version must be the same as %(root_node)s version'
+        ) % {'node_to_add': self.node_to_attach, 'root_node': self.tree.root_node}
+
         self.assertValidatorRaises(
             MatchVersionValidator(self.tree, self.node_to_attach),
             [expected_message]

--- a/program_management/views/tree/paste.py
+++ b/program_management/views/tree/paste.py
@@ -185,7 +185,6 @@ def check_paste(request, node_to_paste) -> List[str]:
         if not request.session.get(check_key):
             check_paste_node_service.check_paste(check_command)
     except osis_common.ddd.interface.BusinessExceptions as business_exception:
-        business_exception.messages.insert(0, node_to_paste['element_code'])
         return business_exception.messages
 
     # cache result to avoid double check


### PR DESCRIPTION
Référence Jira : OSIS-4964

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
