### PR TITLE
[technical/OSIS-4913 => DEV] Formation > Nouvelle formation > lors de la création d_une finalité à partir d_un 2M l_entité de gestion doit être préalimentée

### DIFF
--- a/education_group/views/training/create.py
+++ b/education_group/views/training/create.py
@@ -20,6 +20,7 @@ from education_group.ddd.domain.exception import ContentConstraintTypeMissing, \
     ContentConstraintMinimumMaximumMissing, ContentConstraintMaximumShouldBeGreaterOrEqualsThanMinimum, \
     AcronymAlreadyExist, StartYearGreaterThanEndYear, MaximumCertificateAimType2Reached, CodeAlreadyExistException
 from education_group.ddd.domain.training import TrainingIdentity
+from education_group.ddd.service.read import get_group_service
 from education_group.forms.training import CreateTrainingForm
 from education_group.models.group_year import GroupYear
 from education_group.templatetags.academic_year_display import display_as_academic_year
@@ -30,6 +31,7 @@ from program_management.ddd.domain.node import NodeIdentity
 from program_management.ddd.domain.program_tree import Path
 from program_management.ddd.domain.service.element_id_search import ElementIdSearch
 from program_management.ddd.domain.service.identity_search import NodeIdentitySearch
+from program_management.ddd.service.read import node_identity_service
 from program_management.ddd.service.write import create_and_attach_training_service
 from program_management.ddd.service.write.create_training_with_program_tree import \
     create_and_report_training_with_program_tree
@@ -78,10 +80,16 @@ class TrainingCreateView(LoginRequiredMixin, PermissionRequiredMixin, View):
 
     def _get_initial_form(self) -> Dict:
         request_cache = RequestCache(self.request.user, reverse('version_program'))
+        default_management_entity = None
         if self.get_attach_path():
             default_academic_year = AcademicYear.objects.get(
                 year=self.parent_node_identity.year
             ).year
+            parent_identity = self.get_parent_identity()
+            domain_obj = get_group_service.get_group(
+                command.GetGroupCommand(code=parent_identity.code, year=parent_identity.year)
+            )
+            default_management_entity = domain_obj.management_entity.acronym
         elif request_cache.get_value_cached('academic_year'):
             default_academic_year = AcademicYear.objects.get(
                 id=request_cache.get_value_cached('academic_year')[0]
@@ -89,8 +97,18 @@ class TrainingCreateView(LoginRequiredMixin, PermissionRequiredMixin, View):
         else:
             default_academic_year = starting_academic_year()
         return {
-            'academic_year': default_academic_year
+            'academic_year': default_academic_year,
+            'management_entity': default_management_entity
         }
+
+    def get_parent_identity(self) -> Optional['NodeIdentity']:
+        if self.get_attach_path():
+            cmd_get_node_id = program_management_command.GetNodeIdentityFromElementId(
+                int(self.get_attach_path().split('|')[-1])
+            )
+            parent_id = node_identity_service.get_node_identity_from_element_id(cmd_get_node_id)
+            return parent_id
+        return None
 
     def post(self, request, *args, **kwargs):
         training_form = CreateTrainingForm(


### PR DESCRIPTION
Pull request automatique de technical/OSIS-4913 vers DEV