### PR TITLE
OSIS-5048 : Corrige l'erreur Cannot resolve keyword 'is_current_partn…

### DIFF
--- a/education_group/ddd/repository/training.py
+++ b/education_group/ddd/repository/training.py
@@ -309,7 +309,7 @@ def _get_queryset_to_fetch_data_for_training(entity_ids: List['TrainingIdentity'
                     'organization__organizationaddress_set',
                     OrganizationAddress.objects.all().select_related('country')
                 )
-            ).order_by('all_students')
+            ).select_related('organization').order_by('all_students')
         ),
         Prefetch(
             'administration_entity',


### PR DESCRIPTION
…er' into field. Choices are: acronym, campus, changed, code, educationgrouporganization, entity, external_id, id, logo, name, organizationaddress, prefix, structure, type, uuid

Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
