### PR TITLE
OSIS-4995 fixed calculation of end postponement year for eauch domains (training, minitraining, group, programtree...)

### DIFF
--- a/education_group/ddd/service/write/postpone_mini_training_and_group_modification_service.py
+++ b/education_group/ddd/service/write/postpone_mini_training_and_group_modification_service.py
@@ -68,7 +68,7 @@ def postpone_mini_training_and_group_modification(
             )
         )
     ]
-    end_postponement_year = CalculateEndPostponement.calculate_end_postponement_year(
+    end_postponement_year = CalculateEndPostponement.calculate_end_postponement_year_mini_training(
         identity=from_mini_training_id,
         repository=MiniTrainingRepository()
     )

--- a/education_group/ddd/service/write/postpone_training_and_group_modification_service.py
+++ b/education_group/ddd/service/write/postpone_training_and_group_modification_service.py
@@ -105,7 +105,7 @@ def postpone_training_and_group_modification(postpone_cmd: command.PostponeTrain
             )
         )
     ]
-    end_postponement_year = CalculateEndPostponement.calculate_end_postponement_year(
+    end_postponement_year = CalculateEndPostponement.calculate_end_postponement_year_training(
         identity=from_training_id,
         repository=TrainingRepository()
     )

--- a/education_group/locale/fr_BE/LC_MESSAGES/django.po
+++ b/education_group/locale/fr_BE/LC_MESSAGES/django.po
@@ -187,7 +187,7 @@ msgstr "Conditions"
 msgid ""
 "Consistency error in %(academic_year)s: %(fields)s has already been modified"
 msgstr ""
-"Erreur de consistance en %(academic_year)s: %(field)s a déjà été modifié"
+"Erreur de consistance en %(academic_year)s: %(fields)s a déjà été modifié"
 
 msgid "Contacts"
 msgstr "Contacts"

--- a/education_group/tests/ddd/service/write/test_create_orphan_mini_training_service.py
+++ b/education_group/tests/ddd/service/write/test_create_orphan_mini_training_service.py
@@ -46,7 +46,7 @@ class TestCreateAndPostponeOrphanMiniTraining(TestCase, MockPatcherMixin):
 
     def test_should_return_mini_training_identities(self, mock_postpone_mini_training, mock_create_orphan_group):
         mock_postpone_mini_training.return_value = [
-            mini_training.MiniTrainingIdentity(acronym="ACRON", year=year) for year in range(2021, 2023)
+            mini_training.MiniTrainingIdentity(acronym="ACRON", year=year) for year in range(2020, 2023)
         ]
 
         cmd = CreateMiniTrainingCommandFactory(year=2020, code="CODE", abbreviated_title="ACRON")

--- a/education_group/tests/ddd/service/write/test_create_orphan_training_service.py
+++ b/education_group/tests/ddd/service/write/test_create_orphan_training_service.py
@@ -45,7 +45,7 @@ class TestCreateAndPostponeOrphanTraining(TestCase, MockPatcherMixin):
 
         mock_postpone_training.return_value = [
             training.TrainingIdentity(acronym=cmd.abbreviated_title, year=year)
-            for year in range(2019, 2022)
+            for year in range(2018, 2022)
         ]
 
         result = create_orphan_training_service.create_and_postpone_orphan_training(cmd)

--- a/education_group/tests/ddd/service/write/test_postpone_group_modification_service.py
+++ b/education_group/tests/ddd/service/write/test_postpone_group_modification_service.py
@@ -43,13 +43,11 @@ class TestPostponeGroupModificationService(TestCase):
     @mock.patch('education_group.ddd.service.write.postpone_group_modification_service.'
                 'get_group_service.get_group')
     @mock.patch('education_group.ddd.service.write.postpone_group_modification_service.'
-                'TrainingIdentitySearch.get_from_group_identity')
-    @mock.patch('education_group.ddd.service.write.postpone_group_modification_service.'
                 'ConflictedFields.get_group_conflicted_fields')
     @mock.patch('education_group.ddd.service.write.postpone_group_modification_service.'
                 'update_group_service.update_group')
     @mock.patch('education_group.ddd.service.write.postpone_group_modification_service.'
-                'CalculateEndPostponement.calculate_end_postponement_year')
+                'CalculateEndPostponement.calculate_end_postponement_year_group')
     @mock.patch('education_group.ddd.service.write.postpone_group_modification_service.'
                 'copy_group_service.copy_group')
     def test_ensure_consistency_error_not_stop_creating_group_when_end_postponement_is_undefined(
@@ -58,11 +56,9 @@ class TestPostponeGroupModificationService(TestCase):
             mock_calculate_end_postponement_year,
             mock_update_group_service,
             mock_get_conflicted_fields,
-            mock_training_identity_search,
             mock_get_group
     ):
         mock_get_group.return_value = GroupFactory(type=TrainingType.BACHELOR)
-        mock_training_identity_search.return_value = TrainingIdentity(acronym="DROI2M", year=2020)
         mock_calculate_end_postponement_year.return_value = 2025
         mock_get_conflicted_fields.return_value = {2013: ['credits', 'titles']}
 
@@ -71,11 +67,3 @@ class TestPostponeGroupModificationService(TestCase):
 
         self.assertEqual(mock_update_group_service.call_count, 1)
         self.assertEqual(mock_copy_group_to_next_year_service.call_count, 5)
-
-    @mock.patch('education_group.ddd.service.write.postpone_group_modification_service.'
-                'get_group_service.get_group')
-    def test_ensure_exception_raise_when_group_is_not_a_type_training_mini_training(self, mock_get_group):
-        mock_get_group.return_value = GroupFactory(type=GroupType.COMMON_CORE)
-
-        with self.assertRaises(BusinessException):
-            postpone_group_modification_service.postpone_group_modification_service(self.cmd)

--- a/education_group/tests/ddd/service/write/test_postpone_mini_training_and_group_modification_service.py
+++ b/education_group/tests/ddd/service/write/test_postpone_mini_training_and_group_modification_service.py
@@ -21,7 +21,9 @@
 #  at the root of the source code of this program.  If not,
 #  see http://www.gnu.org/licenses/.
 # ############################################################################
-from unittest import TestCase, mock
+from unittest import mock
+
+from django.test import SimpleTestCase
 
 from education_group.ddd.domain.exception import MiniTrainingCopyConsistencyException
 from education_group.ddd.service.write import postpone_mini_training_and_group_modification_service
@@ -29,7 +31,7 @@ from education_group.tests.ddd.factories.command.postpone_mini_training_and_grou
     PostponeMiniTrainingAndGroupModificationCommandFactory
 
 
-class TestPostponeMiniTrainingAndGroupModificationService(TestCase):
+class TestPostponeMiniTrainingAndGroupModificationService(SimpleTestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.cmd = PostponeMiniTrainingAndGroupModificationCommandFactory(
@@ -41,7 +43,7 @@ class TestPostponeMiniTrainingAndGroupModificationService(TestCase):
     @mock.patch('education_group.ddd.service.write.postpone_mini_training_and_group_modification_service.'
                 'update_mini_training_and_group_service.update_mini_training_and_group')
     @mock.patch('education_group.ddd.service.write.postpone_mini_training_and_group_modification_service.'
-                'CalculateEndPostponement.calculate_end_postponement_year')
+                'CalculateEndPostponement.calculate_end_postponement_year_mini_training')
     @mock.patch('education_group.ddd.service.write.postpone_mini_training_and_group_modification_service.'
                 'copy_mini_training_service.copy_mini_training_to_next_year')
     def test_ensure_consistency_error_not_stop_creating_training_when_end_postponement_is_undefined(

--- a/education_group/tests/ddd/service/write/test_postpone_training_and_group_modification_service.py
+++ b/education_group/tests/ddd/service/write/test_postpone_training_and_group_modification_service.py
@@ -21,7 +21,9 @@
 #  at the root of the source code of this program.  If not,
 #  see http://www.gnu.org/licenses/.
 # ############################################################################
-from unittest import TestCase, mock
+from unittest import mock
+
+from django.test import SimpleTestCase
 
 from education_group.ddd.domain.exception import TrainingCopyConsistencyException
 from education_group.ddd.service.write import postpone_training_and_group_modification_service
@@ -29,10 +31,9 @@ from education_group.tests.ddd.factories.command.postpone_training_and_group_mod
     PostponeTrainingAndGroupModificationCommandFactory
 
 
-class TestPostponeTrainingAndGroupModificationService(TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.cmd = PostponeTrainingAndGroupModificationCommandFactory(
+class TestPostponeTrainingAndGroupModificationService(SimpleTestCase):
+    def setUp(self) -> None:
+        self.cmd = PostponeTrainingAndGroupModificationCommandFactory(
             postpone_from_year=2020
         )
 
@@ -41,7 +42,7 @@ class TestPostponeTrainingAndGroupModificationService(TestCase):
     @mock.patch('education_group.ddd.service.write.postpone_training_and_group_modification_service.'
                 'update_training_and_group_service.update_training_and_group')
     @mock.patch('education_group.ddd.service.write.postpone_training_and_group_modification_service.'
-                'CalculateEndPostponement.calculate_end_postponement_year')
+                'CalculateEndPostponement.calculate_end_postponement_year_training')
     @mock.patch('education_group.ddd.service.write.postpone_training_and_group_modification_service.'
                 'copy_training_service.copy_training_to_next_year')
     def test_ensure_consistency_error_not_stop_creating_training_when_end_postponement_is_undefined(

--- a/program_management/ddd/domain/service/calculate_end_postponement.py
+++ b/program_management/ddd/domain/service/calculate_end_postponement.py
@@ -85,31 +85,6 @@ class CalculateEndPostponement(interface.DomainService):
         return _calculate_end_postponement(identity, repository)
 
     @classmethod
-    def calculate_end_postponement_year(
-            cls,
-            identity: Union['TrainingIdentity', 'MiniTrainingIdentity'],
-            repository: Union['TrainingRepository', 'MiniTrainingRepository']
-    ) -> int:
-        max_year = cls.calculate_end_postponement_limit()
-        obj = repository.get(identity)
-        if obj.end_year is None:
-            return max_year
-        return min(max_year, obj.end_year)
-
-    @classmethod
-    def calculate_program_tree_end_postponement(
-            cls,
-            identity: 'ProgramTreeIdentity',
-            training_repository: 'TrainingRepository',
-            mini_training_repository: 'MiniTrainingRepository'
-    ) -> int:
-        root_identity = TrainingOrMiniTrainingOrGroupIdentitySearch.get_from_program_tree_identity(identity)
-        return cls.calculate_end_postponement_year(
-            identity=root_identity,
-            repository=training_repository if isinstance(root_identity, TrainingIdentity) else mini_training_repository,
-        )
-
-    @classmethod
     def calculate_end_postponement_limit(cls) -> int:
         default_years_to_postpone = DEFAULT_YEARS_TO_POSTPONE
         current_year = academic_year.starting_academic_year().year

--- a/program_management/ddd/domain/service/calculate_end_postponement.py
+++ b/program_management/ddd/domain/service/calculate_end_postponement.py
@@ -30,13 +30,59 @@ from education_group.ddd.business_types import *
 from education_group.ddd.domain.training import TrainingIdentity
 from osis_common.ddd import interface
 from program_management.ddd.domain.program_tree import ProgramTreeIdentity
-from program_management.ddd.domain.service.identity_search import TrainingOrMiniTrainingOrGroupIdentitySearch
-
+from program_management.ddd.domain.program_tree_version import ProgramTreeVersionIdentity
+from program_management.ddd.domain.service.identity_search import TrainingOrMiniTrainingOrGroupIdentitySearch, \
+    ProgramTreeVersionIdentitySearch, ProgramTreeIdentitySearch
+from program_management.ddd.repositories.program_tree import ProgramTreeRepository
+from program_management.ddd.repositories.program_tree_version import ProgramTreeVersionRepository
 
 DEFAULT_YEARS_TO_POSTPONE = 6
 
 
 class CalculateEndPostponement(interface.DomainService):
+
+    @classmethod
+    def calculate_end_postponement_year_mini_training(
+            cls,
+            identity: 'MiniTrainingIdentity',
+            repository: 'MiniTrainingRepository'
+    ):
+        return _calculate_end_postponement(identity, repository)
+
+    @classmethod
+    def calculate_end_postponement_year_training(
+            cls,
+            identity: 'TrainingIdentity',
+            repository: 'TrainingRepository'
+    ):
+        return _calculate_end_postponement(identity, repository)
+
+    @classmethod
+    def calculate_end_postponement_year_group(
+            cls,
+            identity: 'GroupIdentity',
+            repository: 'ProgramTreeVersionRepository'
+    ):
+        # Postponement for orphan groups only works if it is the root group of a program tree
+        tree_identity = ProgramTreeVersionIdentitySearch.get_from_group_identity(identity)
+        return _calculate_end_postponement(tree_identity, repository)
+
+    @classmethod
+    def calculate_end_postponement_year_program_tree(
+            cls,
+            identity: 'ProgramTreeIdentity',
+            repository: 'ProgramTreeVersionRepository'
+    ):
+        version_identity = ProgramTreeVersionIdentitySearch.get_from_program_tree_identity(identity)
+        return cls.calculate_end_postponement_year_program_tree_version(version_identity, repository)
+
+    @classmethod
+    def calculate_end_postponement_year_program_tree_version(
+            cls,
+            identity: 'ProgramTreeVersionIdentity',
+            repository: 'ProgramTreeVersionRepository'
+    ):
+        return _calculate_end_postponement(identity, repository)
 
     @classmethod
     def calculate_end_postponement_year(
@@ -68,3 +114,15 @@ class CalculateEndPostponement(interface.DomainService):
         default_years_to_postpone = DEFAULT_YEARS_TO_POSTPONE
         current_year = academic_year.starting_academic_year().year
         return default_years_to_postpone + current_year
+
+
+def _calculate_end_postponement(identity, repository) -> int:
+    max_year = CalculateEndPostponement.calculate_end_postponement_limit()
+    obj = repository.get(identity)
+    if hasattr(obj, 'end_year_of_existence'):
+        end_year = obj.end_year_of_existence
+    else:
+        end_year = obj.end_year
+    if end_year is None:
+        return max_year
+    return min(max_year, end_year)

--- a/program_management/ddd/domain/service/identity_search.py
+++ b/program_management/ddd/domain/service/identity_search.py
@@ -42,7 +42,9 @@ from program_management.models.education_group_version import EducationGroupVers
 
 
 class ProgramTreeVersionIdentitySearch(interface.DomainService):
-    def get_from_node_identity(self, node_identity: 'NodeIdentity') -> 'ProgramTreeVersionIdentity':
+
+    @classmethod
+    def get_from_node_identity(cls, node_identity: 'NodeIdentity') -> 'ProgramTreeVersionIdentity':
         values = GroupYear.objects.filter(
             partial_acronym=node_identity.code,
             academic_year__year=node_identity.year
@@ -55,6 +57,15 @@ class ProgramTreeVersionIdentitySearch(interface.DomainService):
         if values:
             return ProgramTreeVersionIdentity(**values[0])
         raise interface.BusinessException("Program tree version identity not found")
+
+    @classmethod
+    def get_from_program_tree_identity(cls, identity: 'ProgramTreeIdentity') -> 'ProgramTreeVersionIdentity':
+        return cls.get_from_node_identity(NodeIdentitySearch().get_from_program_tree_identity(identity))
+
+    @classmethod
+    def get_from_group_identity(cls, identity: 'GroupIdentity') -> 'ProgramTreeVersionIdentity':
+        tree_identity = ProgramTreeIdentitySearch().get_from_group_identity(identity)
+        return cls.get_from_program_tree_identity(tree_identity)
 
     @classmethod
     def get_all_program_tree_version_identities(
@@ -136,6 +147,10 @@ class ProgramTreeIdentitySearch(interface.DomainService):
             identity: 'ProgramTreeVersionIdentity'
     ) -> 'ProgramTreeIdentity':
         return self.get_from_node_identity(NodeIdentitySearch().get_from_tree_version_identity(identity))
+
+    @classmethod
+    def get_from_group_identity(cls, group_identity: 'GroupIdentity') -> 'ProgramTreeIdentity':
+        return ProgramTreeIdentity(code=group_identity.code, year=group_identity.year)
 
 
 class TrainingIdentitySearch(interface.DomainService):

--- a/program_management/ddd/service/read/get_end_postponement_year_service.py
+++ b/program_management/ddd/service/read/get_end_postponement_year_service.py
@@ -22,18 +22,16 @@
 #  see http://www.gnu.org/licenses/.
 # ############################################################################
 
-from education_group.ddd.repository.mini_training import MiniTrainingRepository
-from education_group.ddd.repository.training import TrainingRepository
 from program_management.ddd import command
 from program_management.ddd.domain.program_tree import ProgramTreeIdentity
 from program_management.ddd.domain.service.calculate_end_postponement import CalculateEndPostponement
+from program_management.ddd.repositories.program_tree_version import ProgramTreeVersionRepository
 
 
 def calculate_program_tree_end_postponement(
         cmd: command.GetEndPostponementYearCommand
 ) -> int:
-    return CalculateEndPostponement().calculate_program_tree_end_postponement(
+    return CalculateEndPostponement().calculate_end_postponement_year_program_tree(
         identity=ProgramTreeIdentity(cmd.code, cmd.year),
-        training_repository=TrainingRepository(),
-        mini_training_repository=MiniTrainingRepository()
+        repository=ProgramTreeVersionRepository()
     )

--- a/program_management/ddd/service/write/postpone_program_tree_service.py
+++ b/program_management/ddd/service/write/postpone_program_tree_service.py
@@ -27,12 +27,11 @@ from typing import List
 
 from django.db import transaction
 
-from education_group.ddd.repository.mini_training import MiniTrainingRepository
-from education_group.ddd.repository.training import TrainingRepository
 from program_management.ddd.command import PostponeProgramTreeCommand, CopyProgramTreeToNextYearCommand
 from program_management.ddd.domain import exception
 from program_management.ddd.domain.program_tree import ProgramTreeIdentity
 from program_management.ddd.domain.service.calculate_end_postponement import CalculateEndPostponement
+from program_management.ddd.repositories.program_tree_version import ProgramTreeVersionRepository
 from program_management.ddd.service.write import copy_program_tree_service
 
 
@@ -45,10 +44,9 @@ def postpone_program_tree(
 
     # GIVEN
     from_year = postpone_cmd.from_year
-    end_postponement_year = CalculateEndPostponement.calculate_program_tree_end_postponement(
+    end_postponement_year = CalculateEndPostponement.calculate_end_postponement_year_program_tree(
         identity=ProgramTreeIdentity(code=postpone_cmd.from_code, year=postpone_cmd.from_year),
-        training_repository=TrainingRepository(),
-        mini_training_repository=MiniTrainingRepository(),
+        repository=ProgramTreeVersionRepository()
     )
 
     # WHEN

--- a/program_management/ddd/service/write/postpone_program_tree_service_mini_training.py
+++ b/program_management/ddd/service/write/postpone_program_tree_service_mini_training.py
@@ -27,11 +27,10 @@ from typing import List
 
 from django.db import transaction
 
-from education_group.ddd.domain.mini_training import MiniTrainingIdentity
-from education_group.ddd.repository.mini_training import MiniTrainingRepository
 from program_management.ddd.command import PostponeProgramTreeCommand, CopyProgramTreeToNextYearCommand
 from program_management.ddd.domain.program_tree import ProgramTreeIdentity
 from program_management.ddd.domain.service.calculate_end_postponement import CalculateEndPostponement
+from program_management.ddd.repositories.program_tree_version import ProgramTreeVersionRepository
 from program_management.ddd.service.write import copy_program_tree_service
 
 
@@ -44,9 +43,9 @@ def postpone_program_tree(
 
     # GIVEN
     from_year = postpone_cmd.from_year
-    end_postponement_year = CalculateEndPostponement.calculate_end_postponement_year(
-        identity=MiniTrainingIdentity(acronym=postpone_cmd.offer_acronym, year=postpone_cmd.from_year),
-        repository=MiniTrainingRepository()
+    end_postponement_year = CalculateEndPostponement.calculate_end_postponement_year_program_tree(
+        identity=ProgramTreeIdentity(code=postpone_cmd.from_code, year=postpone_cmd.from_year),
+        repository=ProgramTreeVersionRepository()
     )
 
     # WHEN

--- a/program_management/ddd/service/write/postpone_tree_version_service.py
+++ b/program_management/ddd/service/write/postpone_tree_version_service.py
@@ -35,6 +35,7 @@ from program_management.ddd.domain.program_tree import ProgramTreeIdentity
 from program_management.ddd.domain.program_tree_version import ProgramTreeVersionIdentity
 from program_management.ddd.domain.service.calculate_end_postponement import CalculateEndPostponement
 from program_management.ddd.domain.service.identity_search import NodeIdentitySearch, ProgramTreeIdentitySearch
+from program_management.ddd.repositories.program_tree_version import ProgramTreeVersionRepository
 from program_management.ddd.service.write import copy_program_version_service
 
 
@@ -53,10 +54,9 @@ def postpone_program_tree_version(
         year=postpone_cmd.from_year,
         is_transition=postpone_cmd.from_is_transition,
     )
-    end_postponement_year = CalculateEndPostponement.calculate_program_tree_end_postponement(
-        identity=ProgramTreeIdentitySearch().get_from_program_tree_version_identity(program_tree_version_identity),
-        training_repository=TrainingRepository(),
-        mini_training_repository=MiniTrainingRepository(),
+    end_postponement_year = CalculateEndPostponement.calculate_end_postponement_year_program_tree_version(
+        identity=program_tree_version_identity,
+        repository=ProgramTreeVersionRepository()
     )
 
     # WHEN

--- a/program_management/ddd/service/write/postpone_tree_version_service_mini_training.py
+++ b/program_management/ddd/service/write/postpone_tree_version_service_mini_training.py
@@ -34,6 +34,7 @@ from education_group.ddd.repository.training import TrainingRepository
 from program_management.ddd.command import PostponeProgramTreeVersionCommand, CopyTreeVersionToNextYearCommand
 from program_management.ddd.domain.program_tree_version import ProgramTreeVersionIdentity
 from program_management.ddd.domain.service.calculate_end_postponement import CalculateEndPostponement
+from program_management.ddd.repositories.program_tree_version import ProgramTreeVersionRepository
 from program_management.ddd.service.write import copy_program_version_service
 
 
@@ -46,12 +47,14 @@ def postpone_program_tree_version(
 
     # GIVEN
     from_year = postpone_cmd.from_year
-    end_postponement_year = CalculateEndPostponement.calculate_end_postponement_year(
-        identity=MiniTrainingIdentity(
-            acronym=postpone_cmd.from_offer_acronym,
-            year=postpone_cmd.from_year
+    end_postponement_year = CalculateEndPostponement.calculate_end_postponement_year_program_tree_version(
+        identity=ProgramTreeVersionIdentity(
+            offer_acronym=postpone_cmd.from_offer_acronym,
+            version_name=postpone_cmd.from_version_name,
+            year=postpone_cmd.from_year,
+            is_transition=postpone_cmd.from_is_transition,
         ),
-        repository=MiniTrainingRepository()
+        repository=ProgramTreeVersionRepository()
     )
 
     # WHEN

--- a/program_management/ddd/service/write/update_program_tree_version_service.py
+++ b/program_management/ddd/service/write/update_program_tree_version_service.py
@@ -73,7 +73,8 @@ def __call_delete_service(program_tree_version: 'ProgramTreeVersion', end_year_u
     end_year_updated = end_year_updated or postponement_limit
 
     if end_year > end_year_updated:
-        for year_to_delete in range(end_year_updated, program_tree_version.end_year_of_existence or postponement_limit):
+        limit = program_tree_version.end_year_of_existence or postponement_limit + 1
+        for year_to_delete in range(end_year_updated, limit):
             delete_specific_version_service.delete_specific_version(
                 DeleteSpecificVersionCommand(
                     acronym=identity.offer_acronym,

--- a/program_management/tests/ddd/domain/service/test_calculate_end_postponement.py
+++ b/program_management/tests/ddd/domain/service/test_calculate_end_postponement.py
@@ -26,8 +26,11 @@ from unittest import mock
 from django.test import TestCase
 
 from base.tests.factories.academic_year import AcademicYearFactory
-from education_group.tests.ddd.factories.repository.fake import get_fake_training_repository
+from education_group.tests.ddd.factories.group import GroupFactory
+from education_group.tests.ddd.factories.repository.fake import get_fake_training_repository, \
+    get_fake_mini_training_repository, get_fake_group_repository
 from education_group.tests.ddd.factories.training import TrainingFactory
+from education_group.tests.factories.mini_training import MiniTrainingFactory
 from program_management.ddd.domain.program_tree_version import STANDARD
 from program_management.ddd.domain.service.calculate_end_postponement import CalculateEndPostponement
 from program_management.tests.ddd.factories.commands.get_end_postponement_year_command import \
@@ -39,7 +42,7 @@ from program_management.tests.ddd.factories.repository.fake import get_fake_prog
 from testing.mocks import MockPatcherMixin
 
 
-class TestCalculateEndPostponementYearAsTraining(MockPatcherMixin, TestCase):
+class TestCalculateEndPostponementYear(MockPatcherMixin, TestCase):
 
     def setUp(self):
         self.current_year = 2020
@@ -75,65 +78,89 @@ class TestCalculateEndPostponementYearAsTraining(MockPatcherMixin, TestCase):
         mock_starting_academic_year = patcher.start()
         self.addCleanup(patcher.stop)
 
-    @mock.patch("program_management.ddd.domain.service.identity_search._get_data_from_db")
-    def test_when_root_node_is_training_and_end_year_is_none(self, mock_data_from_db):
+    def test_when_end_year_is_none(self):
         training = TrainingFactory(entity_identity__year=self.current_year, end_year=None)
-        mock_data_from_db.return_value = {
-            "offer_acronym": training.entity_identity.acronym,
-            "offer_type": training.type.name
-        }
         fake_training_repository = get_fake_training_repository([training])
-        result = CalculateEndPostponement.calculate_program_tree_end_postponement(
-            identity=self.program_tree.entity_id,
-            training_repository=fake_training_repository,
-            mini_training_repository=None
+        result = CalculateEndPostponement.calculate_end_postponement_year_training(
+            identity=training.entity_id,
+            repository=fake_training_repository,
         )
         self.assertEqual(result, self.maximum_postponement_year)
 
-    @mock.patch("program_management.ddd.domain.service.identity_search._get_data_from_db")
-    def test_when_root_node_is_training_and_end_year_gt_maximum_postponement(self, mock_data_from_db):
+    def test_when_end_year_gt_maximum_postponement(self):
         end_year = self.maximum_postponement_year + 5
         training = TrainingFactory(entity_identity__year=self.current_year, end_year=end_year)
-        mock_data_from_db.return_value = {
-            "offer_acronym": training.entity_identity.acronym,
-            "offer_type": training.type.name
-        }
         fake_training_repository = get_fake_training_repository([training])
-        result = CalculateEndPostponement.calculate_program_tree_end_postponement(
-            identity=self.program_tree.entity_id,
-            training_repository=fake_training_repository,
-            mini_training_repository=None
+        result = CalculateEndPostponement.calculate_end_postponement_year_training(
+            identity=training.entity_id,
+            repository=fake_training_repository,
         )
         self.assertEqual(result, self.maximum_postponement_year)
 
-    @mock.patch("program_management.ddd.domain.service.identity_search._get_data_from_db")
-    def test_when_root_node_is_training_and_end_year_lt_maximum_postponement(self, mock_data_from_db):
+    def test_when_end_year_lt_maximum_postponement(self):
         end_year = self.maximum_postponement_year - 3
         training = TrainingFactory(entity_identity__year=self.current_year, end_year=end_year)
-        mock_data_from_db.return_value = {
-            "offer_acronym": training.entity_identity.acronym,
-            "offer_type": training.type.name
-        }
         fake_training_repository = get_fake_training_repository([training])
-        result = CalculateEndPostponement.calculate_program_tree_end_postponement(
-            identity=self.program_tree.entity_id,
-            training_repository=fake_training_repository,
-            mini_training_repository=None
+        result = CalculateEndPostponement.calculate_end_postponement_year_training(
+            identity=training.entity_id,
+            repository=fake_training_repository,
         )
         self.assertEqual(result, end_year)
 
-    @mock.patch("program_management.ddd.domain.service.identity_search._get_data_from_db")
-    def test_when_root_node_is_training_and_end_year_equals_maximum_postponement(self, mock_data_from_db):
+    def test_when_end_year_equals_maximum_postponement(self):
         end_year = self.maximum_postponement_year
         training = TrainingFactory(entity_identity__year=self.current_year, end_year=end_year)
-        mock_data_from_db.return_value = {
-            "offer_acronym": training.entity_identity.acronym,
-            "offer_type": training.type.name
-        }
         fake_training_repository = get_fake_training_repository([training])
-        result = CalculateEndPostponement.calculate_program_tree_end_postponement(
-            identity=self.program_tree.entity_id,
-            training_repository=fake_training_repository,
-            mini_training_repository=None
+        result = CalculateEndPostponement.calculate_end_postponement_year_training(
+            identity=training.entity_id,
+            repository=fake_training_repository,
+        )
+        self.assertEqual(result, self.maximum_postponement_year)
+
+    def test_calculate_program_tree_version_end_postponement_year(self):
+        result = CalculateEndPostponement.calculate_end_postponement_year_program_tree_version(
+            identity=self.program_tree_version.entity_id,
+            repository=self.fake_program_tree_version_repository,
+        )
+        self.assertEqual(result, self.maximum_postponement_year)
+
+    def test_calculate_mini_training_end_postponement_year(self):
+        end_year = self.maximum_postponement_year - 3
+        mini_training = MiniTrainingFactory(entity_identity__year=self.current_year, end_year=end_year)
+        fake_mini_training_repository = get_fake_mini_training_repository([mini_training])
+        result = CalculateEndPostponement.calculate_end_postponement_year_mini_training(
+            identity=mini_training.entity_id,
+            repository=fake_mini_training_repository,
+        )
+        self.assertEqual(result, end_year)
+
+    @mock.patch(
+        'program_management.ddd.domain.service.identity_search.ProgramTreeVersionIdentitySearch.get_from_group_identity'
+    )
+    def test_calculate_group_end_postponement_year_when_is_root(self, mock_get_from_group_identity):
+        mock_get_from_group_identity.return_value = self.program_tree_version.entity_id
+        end_year = self.maximum_postponement_year - 3
+        group = GroupFactory(
+            entity_identity__year=self.program_tree.entity_id.year,
+            entity_identity__code=self.program_tree.entity_id.code,
+            end_year=end_year
+        )
+        result = CalculateEndPostponement.calculate_end_postponement_year_group(
+            identity=group.entity_id,
+            repository=self.fake_program_tree_version_repository,
+        )
+        assertion_msg = "Should take the end year of the version, not of the group " \
+                        "(end year is not pertinent for groups)"
+        self.assertEqual(result, self.maximum_postponement_year, assertion_msg)
+
+    @mock.patch(
+        'program_management.ddd.domain.service.identity_search.ProgramTreeVersionIdentitySearch.get_from_group_identity'
+    )
+    def test_calculate_program_tree_end_postponement_year(self, mock_get_from_group_identity):
+        mock_get_from_group_identity.return_value = self.program_tree_version.entity_id
+        end_year = self.maximum_postponement_year - 3
+        result = CalculateEndPostponement.calculate_end_postponement_year_mini_training(
+            identity=self.program_tree_version.entity_id,
+            repository=self.fake_program_tree_version_repository,
         )
         self.assertEqual(result, self.maximum_postponement_year)

--- a/program_management/tests/ddd/service/read/test_get_end_postponement_year_service.py
+++ b/program_management/tests/ddd/service/read/test_get_end_postponement_year_service.py
@@ -26,6 +26,7 @@ from unittest import mock
 from django.test import SimpleTestCase
 
 from program_management.ddd.domain.service.calculate_end_postponement import CalculateEndPostponement
+from program_management.ddd.domain.service.identity_search import ProgramTreeVersionIdentitySearch
 from program_management.ddd.service.read import get_end_postponement_year_service
 from program_management.tests.ddd.factories.commands.get_end_postponement_year_command import \
     GetEndPostponementYearCommandFactory
@@ -33,7 +34,7 @@ from program_management.tests.ddd.factories.commands.get_end_postponement_year_c
 
 class TestGetEndPostponementYearService(SimpleTestCase):
 
-    @mock.patch.object(CalculateEndPostponement, 'calculate_program_tree_end_postponement')
+    @mock.patch.object(CalculateEndPostponement, 'calculate_end_postponement_year_program_tree')
     def test_domain_service_is_called(self, mock_domain_service):
         get_end_postponement_year_service.calculate_program_tree_end_postponement(
             GetEndPostponementYearCommandFactory()


### PR DESCRIPTION
Référence Jira : OSIS-4995

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
