### PR TITLE
OSIS-5162 : [TEST]Formation > Arbre > les UE dans le passé ne sont pa…

### DIFF
--- a/base/tests/business/test_learning_unit_xls.py
+++ b/base/tests/business/test_learning_unit_xls.py
@@ -110,7 +110,8 @@ class TestLearningUnitXls(TestCase):
 
         cls.group_element_child = GroupElementYearFactory(
             parent_element=cls.a_group_year_parent_element,
-            child_element=cls.learning_unit_yr_1_element
+            child_element=cls.learning_unit_yr_1_element,
+            relative_credits=cls.learning_unit_yr_1.credits,
         )
         # Particular OF
         cls.create_version(direct_parent_type)

--- a/program_management/serializers/node_view.py
+++ b/program_management/serializers/node_view.py
@@ -182,10 +182,9 @@ def __get_learning_unit_node_icon(link: 'Link') -> str:
 
 
 def __get_learning_unit_node_text(link: 'Link', context=None):
-    text = link.child.code
     if context['root'].year != link.child.year:
-        text += '|{}'.format(link.child.year)
-    return text
+        return "|{}|{}".format(link.child.year, link.child.code)
+    return link.child.code
 
 
 def get_program_tree_version_name(node_identity: 'NodeIdentity', tree_versions: List['ProgramTreeVersion']):

--- a/program_management/tests/serializers/test_node_view.py
+++ b/program_management/tests/serializers/test_node_view.py
@@ -135,7 +135,7 @@ class TestLeafViewSerializer(SimpleTestCase):
 
     def test_serializer_leaf_ensure_text_case_leaf_doesnt_have_same_year_of_root(self):
         self.link.child.year = self.root_node.year - 1
-        expected_text = self.link.child.code + "|" + str(self.link.child.year)
+        expected_text = "|" + str(self.link.child.year) + "|" + self.link.child.code
         serialized_data = _leaf_view_serializer(self.link, self.path, self.tree, context=self.context)
         self.assertEqual(serialized_data['text'], expected_text)
 


### PR DESCRIPTION
…s bien labellisées

Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
