### PR TITLE
OSIS-4954 validate type 2 max aims before updating

### DIFF
--- a/base/auth/roles/program_manager.py
+++ b/base/auth/roles/program_manager.py
@@ -92,6 +92,9 @@ class ProgramManager(EducationGroupRoleModel):
             'base.can_access_learningunit': rules.always_allow,
             'base.can_access_offer': rules.always_allow,
             'base.can_access_student_path': rules.always_allow,
+            'base.can_attach_node': osis_role_predicates.always_deny(
+                message=_("Program manager is not allowed to modify a link")
+            ),
             'base.can_detach_node': osis_role_predicates.always_deny(
                 message=_("Program manager is not allowed to modify a link")
             ),

--- a/education_group/ddd/domain/training.py
+++ b/education_group/ddd/domain/training.py
@@ -296,7 +296,8 @@ class Training(interface.RootEntity):
 
     def update_aims(self, data: 'UpdateDiplomaData'):
         self._update_aims(data.diploma)
-        validators_by_business_action.UpdateCertificateAimsValidatorList(self)
+        validators = validators_by_business_action.UpdateCertificateAimsValidatorList(self)
+        validators.validate()
 
     def update_aims_from_other_training(self, other_training: 'Training'):
         self._update_aims(other_training.diploma)

--- a/education_group/tests/ddd/domain/test_training.py
+++ b/education_group/tests/ddd/domain/test_training.py
@@ -27,7 +27,8 @@ import mock
 from django.test import SimpleTestCase
 
 from education_group.ddd.domain import training, exception
-from education_group.tests.ddd.factories.diploma import DiplomaFactory
+from education_group.ddd.domain.exception import MaximumCertificateAimType2Reached
+from education_group.tests.ddd.factories.diploma import DiplomaFactory, DiplomaAimFactory, DiplomaAimIdentityFactory
 from education_group.tests.ddd.factories.training import TrainingFactory
 
 
@@ -96,3 +97,15 @@ class TestTrainingHasConflictedCertificateAims(SimpleTestCase):
         other_training = TrainingFactory(diploma=DiplomaFactory(aims=['dummy_aim']))
 
         self.assertFalse(training_source.has_conflicted_certificate_aims(other_training))
+
+
+class TestUpdateCertificateAims(SimpleTestCase):
+    def test_should_return_max_type_2_aims_error(self):
+        training_source = TrainingFactory(
+            diploma=DiplomaFactory(
+                aims=[DiplomaAimFactory(entity_id=DiplomaAimIdentityFactory(section=2)) for _ in range(2)]
+            )
+        )
+
+        with self.assertRaises(MaximumCertificateAimType2Reached):
+            training_source.update_aims(data=training.UpdateDiplomaData(diploma=training_source.diploma))


### PR DESCRIPTION
Référence Jira : OSIS-4954

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
