### PR TITLE
OSIS-5130 : en local l'ordre des ue comme dans l'arbre est respecté. …

### DIFF
--- a/program_management/ddd/domain/node.py
+++ b/program_management/ddd/domain/node.py
@@ -354,7 +354,7 @@ class Node(interface.Entity):
         return list_child_nodes_types
 
     @property
-    def descendents(self) -> Dict['Path', 'Node']:   # TODO :: add unit tests
+    def descendents(self) -> OrderedDict['Path', 'Node']:   # TODO :: add unit tests
         return _get_descendents(self)
 
     def update_link_of_direct_child_node(
@@ -421,7 +421,7 @@ class Node(interface.Entity):
         self.children[index+1].order_up()
 
 
-def _get_descendents(root_node: Node, current_path: 'Path' = None) -> Dict['Path', 'Node']:
+def _get_descendents(root_node: Node, current_path: 'Path' = None) -> OrderedDict['Path', 'Node']:
     _descendents = OrderedDict()
     if current_path is None:
         current_path = str(root_node.pk)


### PR DESCRIPTION
… Pas sur la branche déployée???

Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
