### PR TITLE
[technical/OSIS-5180 => DEV] Formation > Arbre > les icônes des propositions ne sont plus visibles sur les UE en proposition

### DIFF
--- a/program_management/serializers/node_view.py
+++ b/program_management/serializers/node_view.py
@@ -96,7 +96,7 @@ def _get_leaf_view_attribute_serializer(link: 'Link', path: str, tree: 'ProgramT
         'search_url': None,
         'has_prerequisite': link.child.has_prerequisite,
         'is_prerequisite': link.child.is_prerequisite,
-        'css_class': __get_css_class(link),
+        'class': __get_css_class(link),
         'element_type': NodeType.LEARNING_UNIT.name,
         'title': __get_title(link),
     })
@@ -104,13 +104,11 @@ def _get_leaf_view_attribute_serializer(link: 'Link', path: str, tree: 'ProgramT
 
 
 def __get_css_class(link: 'Link'):
-    return {
-               ProposalType.CREATION: "proposal proposal_creation",
-               ProposalType.MODIFICATION: "proposal proposal_modification",
-               ProposalType.TRANSFORMATION: "proposal proposal_transformation",
-               ProposalType.TRANSFORMATION_AND_MODIFICATION: "proposal proposal_transformation_modification",
-               ProposalType.SUPPRESSION: "proposal proposal_suppression"
-           }.get(link.child.proposal_type) or ""
+    return {ProposalType.CREATION.name: "proposal proposal_creation",
+            ProposalType.MODIFICATION.name: "proposal proposal_modification",
+            ProposalType.TRANSFORMATION.name: "proposal proposal_transformation",
+            ProposalType.TRANSFORMATION_AND_MODIFICATION.name: "proposal proposal_transformation_modification",
+            ProposalType.SUPPRESSION.name: "proposal proposal_suppression"}.get(link.child.proposal_type) or ""
 
 
 def __get_title(obj: 'Link') -> str:

--- a/program_management/tests/serializers/test_node_view.py
+++ b/program_management/tests/serializers/test_node_view.py
@@ -282,40 +282,40 @@ class TestLeafViewAttributeSerializer(SimpleTestCase):
         self.assertEqual(serialized_data['title'], expected_title)
 
     def test_serializer_node_attr_ensure_get_css_class_proposal_creation(self):
-        self.link.child.proposal_type = ProposalType.CREATION
+        self.link.child.proposal_type = ProposalType.CREATION.name
         expected_css_class = "proposal proposal_creation"
         serialized_data = _get_leaf_view_attribute_serializer(self.link, self.path, self.tree, context=self.context)
-        self.assertEqual(serialized_data['css_class'], expected_css_class)
+        self.assertEqual(serialized_data['class'], expected_css_class)
 
     def test_serializer_node_attr_ensure_get_css_class_proposal_modification(self):
-        self.link.child.proposal_type = ProposalType.MODIFICATION
+        self.link.child.proposal_type = ProposalType.MODIFICATION.name
         expected_css_class = "proposal proposal_modification"
         serialized_data = _get_leaf_view_attribute_serializer(self.link, self.path, self.tree, context=self.context)
-        self.assertEqual(serialized_data['css_class'], expected_css_class)
+        self.assertEqual(serialized_data['class'], expected_css_class)
 
     def test_serializer_node_attr_ensure_get_css_class_proposal_transformation(self):
-        self.link.child.proposal_type = ProposalType.TRANSFORMATION
+        self.link.child.proposal_type = ProposalType.TRANSFORMATION.name
         expected_css_class = "proposal proposal_transformation"
         serialized_data = _get_leaf_view_attribute_serializer(self.link, self.path, self.tree, context=self.context)
-        self.assertEqual(serialized_data['css_class'], expected_css_class)
+        self.assertEqual(serialized_data['class'], expected_css_class)
 
     def test_serializer_node_attr_ensure_get_css_class_proposal_transformation_modification(self):
-        self.link.child.proposal_type = ProposalType.TRANSFORMATION_AND_MODIFICATION
+        self.link.child.proposal_type = ProposalType.TRANSFORMATION_AND_MODIFICATION.name
         expected_css_class = "proposal proposal_transformation_modification"
         serialized_data = _get_leaf_view_attribute_serializer(self.link, self.path, self.tree, context=self.context)
-        self.assertEqual(serialized_data['css_class'], expected_css_class)
+        self.assertEqual(serialized_data['class'], expected_css_class)
 
     def test_serializer_node_attr_ensure_get_css_class_proposal_suppression(self):
-        self.link.child.proposal_type = ProposalType.SUPPRESSION
+        self.link.child.proposal_type = ProposalType.SUPPRESSION.name
         expected_css_class = "proposal proposal_suppression"
         serialized_data = _get_leaf_view_attribute_serializer(self.link, self.path, self.tree, context=self.context)
-        self.assertEqual(serialized_data['css_class'], expected_css_class)
+        self.assertEqual(serialized_data['class'], expected_css_class)
 
     def test_serializer_node_attr_ensure_get_css_class_no_proposal(self):
         self.link.child.proposal_type = None
         expected_css_class = ""
         serialized_data = _get_leaf_view_attribute_serializer(self.link, self.path, self.tree, context=self.context)
-        self.assertEqual(serialized_data['css_class'], expected_css_class)
+        self.assertEqual(serialized_data['class'], expected_css_class)
 
 
 class TestVersionNodeViewSerializerInEn(SimpleTestCase):


### PR DESCRIPTION
Pull request automatique de technical/OSIS-5180 vers DEV