### PR TITLE
OSIS-5281 check prerequisites on parent trees + enhance js tree

### DIFF
--- a/program_management/ddd/repositories/load_tree.py
+++ b/program_management/ddd/repositories/load_tree.py
@@ -23,7 +23,7 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
-
+import copy
 from typing import List, Dict, Any
 
 from base.models import group_element_year
@@ -62,16 +62,19 @@ def load_trees(tree_root_ids: List[int]) -> List['ProgramTree']:
     has_prerequisites = load_prerequisite.load_has_prerequisite_multiple(tree_root_ids, nodes)
     is_prerequisites = load_prerequisite.load_is_prerequisite_multiple(tree_root_ids, nodes)
     for tree_root_id in tree_root_ids:
+        # FIXME Copy links and nodes because it's possible there is a node a present in different trees but
+        #  with different attributes values like prerequisites
+        copy_links = {key: copy.copy(value) for key, value in links.items()}
+        copy_nodes = {key: copy.copy(value) for key, value in nodes.items()}
         root_node = load_node.load(tree_root_id)  # TODO : use load_multiple
-        nodes[root_node.pk] = root_node
+        copy_nodes[root_node.pk] = root_node
         tree_prerequisites = {
             'has_prerequisite_dict': has_prerequisites.get(tree_root_id) or {},
             'is_prerequisite_dict': is_prerequisites.get(tree_root_id) or {},
         }
         structure_for_current_root_node = [s for s in structure if s['starting_node_id'] == tree_root_id]
-        tree = __build_tree(root_node, structure_for_current_root_node, nodes, links, tree_prerequisites)
+        tree = __build_tree(root_node, structure_for_current_root_node, copy_nodes, copy_links, tree_prerequisites)
         trees.append(tree)
-        del nodes[root_node.pk]
     return trees
 
 

--- a/program_management/ddd/validators/_has_or_is_prerequisite.py
+++ b/program_management/ddd/validators/_has_or_is_prerequisite.py
@@ -35,7 +35,7 @@ from program_management.ddd.domain.exception import CannotDetachLearningWhoIsPre
     CannotDetachChildrenWhoArePrerequisiteException, DeletePrerequisitesException
 
 
-class IsTrullyPrerequisiteValidator(business_validator.BusinessValidator):
+class IsPrerequisiteForAllTreesValidator(business_validator.BusinessValidator):
     def __init__(self, parent_node: 'Node', node_to_detach: 'Node', program_tree_repository: 'ProgramTreeRepository'):
         super().__init__()
         self.node_to_detach = node_to_detach

--- a/program_management/ddd/validators/_has_or_is_prerequisite.py
+++ b/program_management/ddd/validators/_has_or_is_prerequisite.py
@@ -35,6 +35,21 @@ from program_management.ddd.domain.exception import CannotDetachLearningWhoIsPre
     CannotDetachChildrenWhoArePrerequisiteException, DeletePrerequisitesException
 
 
+class IsTrullyPrerequisiteValidator(business_validator.BusinessValidator):
+    def __init__(self, parent_node: 'Node', node_to_detach: 'Node', program_tree_repository: 'ProgramTreeRepository'):
+        super().__init__()
+        self.node_to_detach = node_to_detach
+        self.parent_node = parent_node
+        self.program_tree_repository = program_tree_repository
+
+    def validate(self, *args, **kwargs):
+        trees = self.program_tree_repository.search_from_children([self.parent_node.entity_id])
+        for tree in trees:
+            parent_path = tree.get_node_smallest_ordered_path(self.parent_node)
+            node_to_detach = tree.get_node_by_code_and_year(self.node_to_detach.code, self.node_to_detach.year)
+            IsPrerequisiteValidator(tree, parent_path, node_to_detach).validate()
+
+
 class IsPrerequisiteValidator(business_validator.BusinessValidator):
 
     def __init__(self, tree: 'ProgramTree', path_to_parent: 'Path', node_to_detach: 'Node'):

--- a/program_management/ddd/validators/validators_by_business_action.py
+++ b/program_management/ddd/validators/validators_by_business_action.py
@@ -45,7 +45,8 @@ from program_management.ddd.validators._delete_check_versions_end_date import Ch
 from program_management.ddd.validators._detach_option_2M import DetachOptionValidator
 from program_management.ddd.validators._detach_root import DetachRootValidator
 from program_management.ddd.validators._empty_program_tree import EmptyProgramTreeValidator
-from program_management.ddd.validators._has_or_is_prerequisite import IsPrerequisiteValidator
+from program_management.ddd.validators._has_or_is_prerequisite import IsPrerequisiteValidator, \
+    IsTrullyPrerequisiteValidator
 from program_management.ddd.validators._infinite_recursivity import InfiniteRecursivityTreeValidator
 from program_management.ddd.validators._match_version import MatchVersionValidator
 from program_management.ddd.validators._minimum_editable_year import \
@@ -180,7 +181,7 @@ class DetachNodeValidatorList(MultipleExceptionBusinessListValidator):
                 DetachRootValidator(tree, path_to_node_to_detach),
                 MinimumEditableYearValidator(tree),
                 DetachAuthorizedRelationshipValidator(tree, node_to_detach, detach_from),
-                IsPrerequisiteValidator(tree, path_to_parent, node_to_detach),
+                IsTrullyPrerequisiteValidator(detach_from, node_to_detach, tree_repository),
                 DetachOptionValidator(tree, path_to_node_to_detach, tree_repository),
             ]
 
@@ -188,7 +189,7 @@ class DetachNodeValidatorList(MultipleExceptionBusinessListValidator):
             self.validators = [
                 AuthorizedRelationshipLearningUnitValidator(tree, node_to_detach, detach_from),
                 MinimumEditableYearValidator(tree),
-                IsPrerequisiteValidator(tree, path_to_parent, node_to_detach),
+                IsTrullyPrerequisiteValidator(detach_from, node_to_detach, tree_repository),
             ]
 
         else:

--- a/program_management/ddd/validators/validators_by_business_action.py
+++ b/program_management/ddd/validators/validators_by_business_action.py
@@ -46,7 +46,7 @@ from program_management.ddd.validators._detach_option_2M import DetachOptionVali
 from program_management.ddd.validators._detach_root import DetachRootValidator
 from program_management.ddd.validators._empty_program_tree import EmptyProgramTreeValidator
 from program_management.ddd.validators._has_or_is_prerequisite import IsPrerequisiteValidator, \
-    IsTrullyPrerequisiteValidator
+    IsPrerequisiteForAllTreesValidator
 from program_management.ddd.validators._infinite_recursivity import InfiniteRecursivityTreeValidator
 from program_management.ddd.validators._match_version import MatchVersionValidator
 from program_management.ddd.validators._minimum_editable_year import \
@@ -181,7 +181,7 @@ class DetachNodeValidatorList(MultipleExceptionBusinessListValidator):
                 DetachRootValidator(tree, path_to_node_to_detach),
                 MinimumEditableYearValidator(tree),
                 DetachAuthorizedRelationshipValidator(tree, node_to_detach, detach_from),
-                IsTrullyPrerequisiteValidator(detach_from, node_to_detach, tree_repository),
+                IsPrerequisiteForAllTreesValidator(detach_from, node_to_detach, tree_repository),
                 DetachOptionValidator(tree, path_to_node_to_detach, tree_repository),
             ]
 
@@ -189,7 +189,7 @@ class DetachNodeValidatorList(MultipleExceptionBusinessListValidator):
             self.validators = [
                 AuthorizedRelationshipLearningUnitValidator(tree, node_to_detach, detach_from),
                 MinimumEditableYearValidator(tree),
-                IsTrullyPrerequisiteValidator(detach_from, node_to_detach, tree_repository),
+                IsPrerequisiteForAllTreesValidator(detach_from, node_to_detach, tree_repository),
             ]
 
         else:

--- a/program_management/locale/en/LC_MESSAGES/djangojs.po
+++ b/program_management/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-28 11:21+0200\n"
+"POT-Creation-Date: 2020-11-03 12:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -36,16 +36,25 @@ msgstr ""
 msgid "Existing name version"
 msgstr ""
 
+msgid "Forbidden because of prerequisites"
+msgstr ""
+
 msgid "Invalid name version"
 msgstr ""
 
 msgid "Modify the link"
 msgstr ""
 
+msgid "New version"
+msgstr ""
+
 msgid "Open all"
 msgstr ""
 
 msgid "Paste"
+msgstr ""
+
+msgid "Prolong"
 msgstr ""
 
 msgid "Search"

--- a/program_management/locale/fr_BE/LC_MESSAGES/djangojs.po
+++ b/program_management/locale/fr_BE/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-28 11:21+0200\n"
+"POT-Creation-Date: 2020-11-03 12:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,17 +35,26 @@ msgstr "Cette version existe dans le passé en "
 msgid "Existing name version"
 msgstr "Cette version existe déjà"
 
+msgid "Forbidden because of prerequisites"
+msgstr "Interdit à cause des prérequis"
+
 msgid "Invalid name version"
 msgstr "Sigle de version invalide"
 
 msgid "Modify the link"
 msgstr "Modifier le lien"
 
+msgid "New version"
+msgstr "Nouvelle version"
+
 msgid "Open all"
 msgstr "Ouvrir tout"
 
 msgid "Paste"
 msgstr "Coller"
+
+msgid "Prolong"
+msgstr "Prolonger"
 
 msgid "Search"
 msgstr "Rechercher"

--- a/program_management/static/js/program_management/education_group_tree.js
+++ b/program_management/static/js/program_management/education_group_tree.js
@@ -300,17 +300,22 @@ function initializeJsTree($documentTree, tree_json_url, cut_element_url, copy_el
             "contextmenu": {
                 "select_node": false,
                 "items": function ($node) {
+                    let has_or_is_prerequisite = $node.a_attr.is_prerequisite === true || $node.a_attr.has_prerequisite === true;
+                    let detach_msg = has_or_is_prerequisite ? gettext('Forbidden because of prerequisites') : null;
+                    let cut_msg = has_or_is_prerequisite ?  gettext('Forbidden because of prerequisites') : null;
+
                     return {
                         "cut": {
                             "label": gettext("Cut"),
                             "_disabled": function (data) {
                                 let __ret = get_data_from_tree(data);
-                                return !__ret.group_element_year_id || __ret.is_prerequisite === true;
+                                return !__ret.group_element_year_id || has_or_is_prerequisite;
                             },
                             "action": function (data) {
                                 const node_data = get_data_from_tree(data);
                                 handleCutAction(cut_element_url, node_data.element_code, node_data.element_year, node_data.path)
-                            }
+                            },
+                            "title": cut_msg
                         },
 
                         "copy": {
@@ -364,10 +369,10 @@ function initializeJsTree($documentTree, tree_json_url, cut_element_url, copy_el
 
                                 });
                             },
-                            "title": $node.a_attr.detach_msg,
+                            "title": detach_msg,
                             "_disabled": function (data) {
                                 let __ret = get_data_from_tree(data);
-                                return __ret.detach_url == null || __ret.is_prerequisite === true;
+                                return __ret.detach_url == null || has_or_is_prerequisite;
                             }
                         },
 


### PR DESCRIPTION
Check that the node to detach is not a prerequisite in other
trees containing the parent node.
Also disable possibility to detach or cut a node which
have prerequisites on the js tree and display a tooltip
showing why.

Référence Jira : OSIS-5281
