### PR TITLE
[technical/OSIS-5270 => DEV] Formations > Arbre > Rechercher : la modale n_est plus indépendante Formations/UE

### DIFF
--- a/base/utils/cache.py
+++ b/base/utils/cache.py
@@ -63,7 +63,7 @@ class CacheFilterMixin:
     # Mixin that keep the cache for cbv.
     def get(self, request, *args, **kwargs):
         request_cache = RequestCache(user=request.user, path=request.path)
-        if request.GET:
+        if self.__have_data_to_cached(request):
             request_cache.save_get_parameters(
                 request,
                 parameters_to_exclude=self.cache_exclude_params,
@@ -71,6 +71,9 @@ class CacheFilterMixin:
             )
         request.GET = request_cache.restore_get_request(request)
         return super().get(request, *args, **kwargs)
+
+    def __have_data_to_cached(self, request) -> bool:
+        return bool(set(request.GET.keys()) - set(self.cache_exclude_params or []))
 
 
 class OsisCache(abc.ABC):

--- a/program_management/templates/quick_search_egy_inner.html
+++ b/program_management/templates/quick_search_egy_inner.html
@@ -8,7 +8,7 @@
         <li role="presentation" class="active"><a id="link-quick-search-educationgroup" href="#">{% trans 'Trainings' %}</a></li>
         {% if display_quick_search_luy_link %}
         <li role="presentation">
-            <a id="link-quick-search-learningunit" href="#" class="trigger_modal" data-url="{% url "quick_search_learning_unit" year %}?{{ request.GET.urlencode }}">
+            <a id="link-quick-search-learningunit" href="#" class="trigger_modal" data-url="{{ quick_search_learning_unit_url }}">
                 {% trans 'Learning units' %}
             </a>
         </li>

--- a/program_management/templates/quick_search_luy_inner.html
+++ b/program_management/templates/quick_search_luy_inner.html
@@ -6,7 +6,7 @@
 {% block navbar %}
     <ul class="nav nav-tabs" role="tablist">
         <li role="presentation">
-            <a id="link-quick-search-educationgroup" class="trigger_modal" data-url="{% url "quick_search_education_group" year %}?{{ request.GET.urlencode }}">
+            <a id="link-quick-search-educationgroup" class="trigger_modal" data-url="{{ quick_search_education_group_url }}">
                 {% trans 'Trainings' %}
             </a>
         </li>

--- a/program_management/tests/views/test_quicksearch.py
+++ b/program_management/tests/views/test_quicksearch.py
@@ -56,6 +56,16 @@ class TestQuickSearchLearningUnitYearView(TestCase):
         self.assertTemplateUsed(response, 'quick_search_luy_inner.html')
         self.assertFalse(list(response.context['page_obj']))
 
+    def test_assert_context_keys(self):
+        response = self.client.get(self.url, data={'path': self.path})
+
+        expected_url = reverse_with_get(
+            "quick_search_education_group",
+            args=[self.root_element.group_year.academic_year.year],
+            get={'path': self.path}
+        )
+        self.assertEqual(response.context['quick_search_education_group_url'], expected_url)
+
     def test_learning_unit_search_filter(self):
         response = self.client.get(self.url, data={'title': 'dead', 'path': self.path})
         self.assertTemplateUsed(response, 'quick_search_luy_inner.html')
@@ -91,6 +101,16 @@ class TestQuickSearchGroupYearView(TestCase):
         response = self.client.get(self.url, data={'path': self.path})
         self.assertTemplateUsed(response, 'quick_search_egy_inner.html')
         self.assertFalse(list(response.context['page_obj']))
+
+    def test_assert_context_keys(self):
+        response = self.client.get(self.url, data={'path': self.path})
+
+        expected_url = reverse_with_get(
+            "quick_search_learning_unit",
+            args=[self.root_element.group_year.academic_year.year],
+            get={'path': self.path}
+        )
+        self.assertEqual(response.context['quick_search_learning_unit_url'], expected_url)
 
     def test_education_group_search_filter(self):
         response = self.client.get(self.url, data={'title': 'Rav', 'path': self.path})

--- a/program_management/views/quick_search.py
+++ b/program_management/views/quick_search.py
@@ -34,6 +34,7 @@ from base.models.academic_year import AcademicYear
 from base.models.learning_unit_year import LearningUnitYear
 from base.utils.cache import CacheFilterMixin
 from base.utils.search import SearchMixin
+from base.utils.urls import reverse_with_get
 from base.views.mixins import AjaxTemplateMixin
 from education_group.views.serializers.group_year import GroupYearSerializer
 from education_group.models.group_year import GroupYear
@@ -112,7 +113,7 @@ class QuickSearchGroupYearView(PermissionRequiredMixin, CacheFilterMixin, AjaxTe
     timeout = CACHE_TIMEOUT
 
     filterset_class = QuickGroupYearFilter
-    cache_exclude_params = ['page']
+    cache_exclude_params = ['page', 'path']
     paginate_by = "12"
     ordering = ('academic_year', 'acronym', 'partial_acronym')
 
@@ -132,6 +133,7 @@ class QuickSearchGroupYearView(PermissionRequiredMixin, CacheFilterMixin, AjaxTe
         context['display_quick_search_luy_link'] = self.is_learning_unit_child_allowed()
         context['node_path'] = self.request.GET["path"]
         context['year'] = self.kwargs["year"]
+        context['quick_search_learning_unit_url'] = self.get_quick_search_learning_unit_url()
         return context
 
     def render_to_response(self, context, **response_kwargs):
@@ -146,6 +148,14 @@ class QuickSearchGroupYearView(PermissionRequiredMixin, CacheFilterMixin, AjaxTe
         element_id = int(self.request.GET["path"].split("|")[-1])
         return GroupYear.objects.get(element__id=element_id).education_group_type.learning_unit_child_allowed
 
+    def get_quick_search_learning_unit_url(self):
+        queryparams = {'path': self.request.GET['path']} if 'path' in self.request.GET else {}
+        return reverse_with_get(
+            "quick_search_learning_unit",
+            args=[self.kwargs['year']],
+            get=queryparams
+        )
+
 
 class QuickSearchLearningUnitYearView(PermissionRequiredMixin, CacheFilterMixin, AjaxTemplateMixin, SearchMixin,
                                       FilterView):
@@ -155,7 +165,7 @@ class QuickSearchLearningUnitYearView(PermissionRequiredMixin, CacheFilterMixin,
     timeout = CACHE_TIMEOUT
 
     filterset_class = QuickLearningUnitYearFilter
-    cache_exclude_params = ['page']
+    cache_exclude_params = ['page', 'path']
     paginate_by = "12"
     ordering = ('academic_year', 'acronym')
 
@@ -174,6 +184,7 @@ class QuickSearchLearningUnitYearView(PermissionRequiredMixin, CacheFilterMixin,
         context['form'] = context["filter"].form
         context['node_path'] = self.request.GET["path"]
         context['year'] = self.kwargs["year"]
+        context['quick_search_education_group_url'] = self.get_quick_search_education_group_url()
         return context
 
     def render_to_response(self, context, **response_kwargs):
@@ -183,3 +194,11 @@ class QuickSearchLearningUnitYearView(PermissionRequiredMixin, CacheFilterMixin,
 
     def get_paginate_by(self, queryset):
         return self.paginate_by
+
+    def get_quick_search_education_group_url(self):
+        queryparams = {'path': self.request.GET['path']} if 'path' in self.request.GET else {}
+        return reverse_with_get(
+            "quick_search_education_group",
+            args=[self.kwargs['year']],
+            get=queryparams
+        )


### PR DESCRIPTION
Pull request automatique de technical/OSIS-5270 vers DEV