### PR TITLE
OSIS-4243 fix display issues with score encoding landing page

### DIFF
--- a/assessments/locale/fr_BE/LC_MESSAGES/django.po
+++ b/assessments/locale/fr_BE/LC_MESSAGES/django.po
@@ -162,7 +162,7 @@ msgid "Definitive submission (Submit to faculty)"
 msgstr "Soumission définitive (Soumettre à la faculté)"
 
 msgid "Display all deadlines for this learning unit"
-msgstr "Afficher toutes les dates d'échéances pour cette unité d'enseignement"
+msgstr "Afficher toutes les dates d'échéance pour cette unité d'enseignement"
 
 msgid "Display all tutors for this learning unit"
 msgstr "Afficher tous les tuteurs pour cette unité d'enseignement"

--- a/assessments/templates/blocks/deadline_tutor_display.html
+++ b/assessments/templates/blocks/deadline_tutor_display.html
@@ -24,11 +24,13 @@
 {% endcomment %}
 
 {% if deadline|is_past %}
-    <strong class="error">{{ deadline|date:"d/m/Y" }}</strong>
+    <strong class="error" style="width: 7em; display: inline-block">{{ deadline|date:"d/m/Y" }}</strong>
 {% else %}
-    <span>{{ deadline|date:"d/m/Y" }}</span>
+    <span style="width: 7em; display: inline-block">{{ deadline|date:"d/m/Y" }}</span>
 {% endif %}
 <span title="{% trans 'Remaining scores to submit for this deadline' %}"
-      class="label {% if scores_not_yet_submitted == 0 %}label-success{% else %}label-warning{% endif %}">
-                                        {{ scores_not_yet_submitted }}
+      class="badge badge-default {% if note_detail.exam_enrollments_encoded == 0%}background-grey
+                   {% elif scores_not_yet_submitted == 0 %}background-success
+                   {% else %}background-warning{% endif %}">
+    {{ scores_not_yet_submitted }}
 </span>

--- a/assessments/templates/scores_encoding.html
+++ b/assessments/templates/scores_encoding.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% load i18n %}
 {% load static %}
-{% load dictionnary %}
+{% load dictionnary tutor_deadline%}
 {% load format %}
 {% comment "License" %}
 * OSIS stands for Open Student Information System. It's an application
@@ -100,6 +100,7 @@
                             <tr>
                                 <th>{% trans 'Acronym' context 'UE acronym' %}</th>
                                 <th>{% trans 'Learning unit' %}</th>
+                                <th id="tutor_deadlines">{% trans 'Tutor deadlines' %}</th>
                                 <th>{% trans 'Progress' %}</th>
                                 <th></th>
                             </tr>
@@ -110,6 +111,36 @@
                                 <td>{{ note_detail.learning_unit_year_acronym }}</td>
                                 <td><a href="{% url 'online_encoding' note_detail.learning_unit_year_id %}?{{ request.GET.urlencode }}"
                                            id="lnk_{{ note_detail.learning_unit_year_acronym }}">{{ note_detail.learning_unit_year_title }}</a>
+                                </td>
+                                <td headers="tutor_deadlines">
+                                    {% with note_detail.remaining_scores_by_deadline|ordered_deadlines_to_display as deadlines %}
+                                        {% if deadlines %}
+                                            {% with first_item=deadlines|get_first_item %}
+                                                {% with deadline=first_item.0 scores_not_yet_submitted=first_item.1 %}
+                                                    <p>
+                                                        {% include "blocks/deadline_tutor_display.html" %}
+                                                        {% if deadlines|length > 1 %}
+                                                            <a role="button" data-toggle="collapse" data-target="#tutor_deadlines_collapse_{{ note_detail.learning_unit_year_acronym }}"
+                                                               aria-expanded="false"
+                                                               class="col-md-offset-1"
+                                                               aria-controls="tutor_deadlines_collapse_{{ note_detail.learning_unit_year_acronym }}"
+                                                               title="{% trans 'Display all deadlines for this learning unit' %}">
+                                                                <span class="glyphicon glyphicon-list" aria-hidden="true"></span>
+                                                            </a>
+                                                        {% endif %}
+                                                    </p>
+                                                {% endwith %}
+                                            {% endwith %}
+                                            <div class="collapse {% if tutor %}in{% endif %}"
+                                                 id="tutor_deadlines_collapse_{{ note_detail.learning_unit_year_acronym }}">
+                                                {% with deadlines_without_first=deadlines|remove_first %}
+                                                    {% for deadline, scores_not_yet_submitted in deadlines_without_first.items %}
+                                                        <p>{% include "blocks/deadline_tutor_display.html" %}</p>
+                                                    {% endfor %}
+                                                {% endwith %}
+                                            </div>
+                                        {% endif %}
+                                    {% endwith %}
                                 </td>
                                 <td id="txt_progress_{{ note_detail.learning_unit_year_acronym }}" >
                                     <div class="progress">

--- a/assessments/views/score_encoding.py
+++ b/assessments/views/score_encoding.py
@@ -150,6 +150,8 @@ def scores_encoding(request):
         score_encoding_progress_list = score_encoding_progress. \
             append_related_tutors_and_score_responsibles(score_encoding_progress_list)
 
+        score_encoding_progress_list = score_encoding_progress.group_by_learning_unit_year(score_encoding_progress_list)
+
         if incomplete_encodings_only:
             score_encoding_progress_list = score_encoding_progress.filter_only_incomplete(score_encoding_progress_list)
 
@@ -180,6 +182,7 @@ def scores_encoding(request):
             number_session=number_session,
             academic_year=academic_yr
         )
+        score_encoding_progress.group_by_learning_unit_year(score_encoding_progress_list)
         all_offers = score_encoding_progress.find_related_offer_years(score_encoding_progress_list)
 
         context.update({'tutor': tutor,
@@ -191,8 +194,7 @@ def scores_encoding(request):
     else:
         filtered_list = []
     context.update({
-        'notes_list': score_encoding_progress.group_by_learning_unit_year(score_encoding_progress_list)
-        if not offer_year_id else filtered_list
+        'notes_list': score_encoding_progress_list if not offer_year_id else filtered_list
     })
 
     return render(request, template_name, context)

--- a/base/static/css/osis.css
+++ b/base/static/css/osis.css
@@ -681,3 +681,15 @@ input::-webkit-inner-spin-button {
 .without_arrow input[type=number] {
     -moz-appearance: textfield;
 }
+
+.background-grey {
+    background-color: lightgrey;
+}
+
+.background-success {
+    background-color: #5cb85c;
+}
+
+.background-warning {
+    background-color: #f0ad4e;
+}


### PR DESCRIPTION
- display badges in place of label for scores missing
- display grey badge on learning unit with no scores encoded
- align teacher deadline cells
- display also teacher deadline for tutors
- compute progression based on whole data and not only incomplete

Référence Jira : OSIS-4243

