### PR TITLE
[hotfix/OSIS-4606 => QA] En version FR, l_intitulé du fichier Excel _Comparaison entre unités d_enseignement_ produit à partir des onglets de l_UE est en anglais

### DIFF
--- a/base/business/learning_units/xls_comparison.py
+++ b/base/business/learning_units/xls_comparison.py
@@ -58,8 +58,8 @@ EMPTY_VALUE = ''
 DATE_FORMAT = '%d-%m-%Y'
 DATE_TIME_FORMAT = '%d-%m-%Y %H:%M'
 DESC = "desc"
-WORKSHEET_TITLE = 'learning_units_comparison'
-XLS_FILENAME = 'learning_units_comparison'
+WORKSHEET_TITLE = _('Comparison of LUs')
+XLS_FILENAME = _('learning_units_comparison')
 XLS_DESCRIPTION = _("Comparison of learning units")
 
 ACRONYM_COL_NUMBER = 0

--- a/base/locale/en/LC_MESSAGES/django.po
+++ b/base/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-16 14:58+0100\n"
+"POT-Creation-Date: 2020-11-23 10:52+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -530,6 +530,9 @@ msgstr ""
 msgid "Common title"
 msgstr ""
 
+msgid "Comparison of LUs"
+msgstr ""
+
 msgid "Comparison of learning units"
 msgstr ""
 
@@ -1044,6 +1047,10 @@ msgstr ""
 msgid "Global ID"
 msgstr ""
 
+msgid "Go"
+msgstr ""
+
+msgctxt "carousel"
 msgid "Go"
 msgstr ""
 
@@ -3098,6 +3105,9 @@ msgid "items per page"
 msgstr ""
 
 msgid "learning unit year"
+msgstr ""
+
+msgid "learning_units_comparison"
 msgstr ""
 
 msgid "list of required teaching materials"

--- a/base/locale/fr_BE/LC_MESSAGES/django.po
+++ b/base/locale/fr_BE/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-16 14:58+0100\n"
+"POT-Creation-Date: 2020-11-23 10:52+0100\n"
 "PO-Revision-Date: 2019-04-15 08:35+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -545,6 +545,9 @@ msgstr "Partie commune"
 
 msgid "Common title"
 msgstr "Intitulé commun"
+
+msgid "Comparison of LUs"
+msgstr "Comparaison entre UEs"
 
 msgid "Comparison of learning units"
 msgstr "Liste comparative d'unités d'enseignement"
@@ -3265,6 +3268,9 @@ msgstr "éléments par page"
 
 msgid "learning unit year"
 msgstr "unité d'enseignement annualisée"
+
+msgid "learning_units_comparison"
+msgstr "comparaison_entre_UEs"
 
 msgid "list of required teaching materials"
 msgstr "liste des supports de cours obligatoires"


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-4606 vers QA