### PR TITLE
OSIS-5141 Disable publish button only for past LUYs

### DIFF
--- a/attribution/tests/views/test_manage_my_courses.py
+++ b/attribution/tests/views/test_manage_my_courses.py
@@ -228,6 +228,7 @@ class TestViewEducationalInformation(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.tutor = TutorFactory()
+        AcademicYearFactory.produce()
         cls.attribution = AttributionFactory(tutor=cls.tutor, summary_responsible=True)
         cls.url = reverse(view_educational_information, args=[cls.attribution.learning_unit_year.id])
         cls.tutor.person.user.user_permissions.add(Permission.objects.get(codename='can_edit_learningunit_pedagogy'))

--- a/base/templates/learning_unit/pedagogy.html
+++ b/base/templates/learning_unit/pedagogy.html
@@ -40,7 +40,7 @@
            data-toggle="tooltip"
            {% if not can_edit_information and not can_edit_force_majeur_section %}
                 title="{% trans 'You do not have the permission to refresh the publication for this learning unit' %}"
-           {% elif not luy_in_current_academic_year %}
+           {% elif not luy_in_current_or_future_anac %}
                 title="{% trans 'You do not have the permission to refresh the publication for this year' %}"
            {% endif %}>
            {% trans 'Refresh and visualize publication' %}

--- a/base/tests/views/test_learning_unit.py
+++ b/base/tests/views/test_learning_unit.py
@@ -859,7 +859,7 @@ class LearningUnitViewTestCase(TestCase):
         mock_perm_pedagogy.return_value = True
         response = self.client.get(reverse(learning_unit_pedagogy, args=[self.luy.pk]))
 
-        self.assertTrue(response.context['luy_in_current_academic_year'])
+        self.assertTrue(response.context['luy_in_current_or_future_anac'])
         self.assertTrue(response.context['enable_publish_button'])
 
     @mock.patch(
@@ -870,7 +870,7 @@ class LearningUnitViewTestCase(TestCase):
         mock_perm_force_majeure.return_value = False
         response = self.client.get(reverse(learning_unit_pedagogy, args=[self.luy.pk]))
 
-        self.assertTrue(response.context['luy_in_current_academic_year'])
+        self.assertTrue(response.context['luy_in_current_or_future_anac'])
         self.assertFalse(response.context['enable_publish_button'])
 
     def test_learning_unit_specification(self):

--- a/base/views/learning_units/pedagogy/read.py
+++ b/base/views/learning_units/pedagogy/read.py
@@ -41,7 +41,6 @@ from base.business.learning_unit import CMS_LABEL_PEDAGOGY_FR_ONLY, \
 from base.business.learning_units import perms
 from base.business.learning_units.perms import is_eligible_to_update_learning_unit_pedagogy, \
     is_eligible_to_update_learning_unit_pedagogy_force_majeure_section
-from base.models import academic_year
 from base.models.person import Person
 from base.models.teaching_material import TeachingMaterial
 from base.views.common import add_to_session
@@ -71,9 +70,9 @@ def read_learning_unit_pedagogy(request, learning_unit_year_id: int, context, te
         learning_unit_year,
         person
     )
-    luy_in_current_academic_year = learning_unit_year.academic_year in academic_year.current_academic_years()
-    context['luy_in_current_academic_year'] = luy_in_current_academic_year
-    context['enable_publish_button'] = (perm_to_edit or perm_to_edit_force_majeure) and luy_in_current_academic_year
+    luy_in_current_or_future_anac = not learning_unit_year.academic_year.is_past
+    context['luy_in_current_or_future_anac'] = luy_in_current_or_future_anac
+    context['enable_publish_button'] = (perm_to_edit or perm_to_edit_force_majeure) and luy_in_current_or_future_anac
 
     user_language = mdl.person.get_user_interface_language(request.user)
 


### PR DESCRIPTION
Référence Jira : OSIS-5141

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
