### PR TITLE
OSIS-5372 do not call 'persist prerequisite' if node does not have prerequisites

### DIFF
--- a/program_management/ddd/repositories/persist_tree.py
+++ b/program_management/ddd/repositories/persist_tree.py
@@ -128,10 +128,14 @@ def __delete_links(tree: 'ProgramTree', node: 'Node'):
 
 def __persist_deleted_prerequisites(tree: 'ProgramTree', node: 'Node'):
     if node.is_learning_unit():
-        _persist_prerequisite._persist(tree.root_node, node)
+        prerequisite = tree.get_prerequisite(node)
+        if prerequisite:
+            _persist_prerequisite._persist(tree.root_node, prerequisite)
     else:
         for child_node in node.get_all_children_as_learning_unit_nodes():
-            _persist_prerequisite._persist(tree.root_node, child_node)
+            prerequisite = tree.get_prerequisite(child_node)
+            if prerequisite:
+                _persist_prerequisite._persist(tree.root_node, prerequisite)
 
 
 def __delete_group_element_year(link):


### PR DESCRIPTION
Référence Jira : OSIS-5372

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
