### PR TITLE
OSIS-4205 return none LUs when borrowing faculty has none inside OF

### DIFF
--- a/base/forms/learning_unit/search/borrowed.py
+++ b/base/forms/learning_unit/search/borrowed.py
@@ -124,9 +124,10 @@ def _get_management_entity_of_roots_by_elements(
 
     dict_group_year_entities_for_learning_unit_year = defaultdict(list)
     for list_element in root_child_lists:
-        dict_group_year_entities_for_learning_unit_year[list_element["child_id"]].append(
-            dict_entity_of_element_id.get(list_element["root_id"])
-        )
+        if dict_entity_of_element_id.get(list_element["root_id"]):
+            dict_group_year_entities_for_learning_unit_year[list_element["child_id"]].append(
+                dict_entity_of_element_id.get(list_element["root_id"])
+            )
     return dict_group_year_entities_for_learning_unit_year
 
 


### PR DESCRIPTION
When giving a borrowing faculty that had all of its formations
not containing any Learning Units, the borrowing search would
return all Learning Units for a given year.

Référence Jira : OSIS-4205

