### PR TITLE
[hotfix/OSIS-5627 => QA] [Echec Qa] - Formation > Générer le PDF > AttributeError > _list_ object has no attribute _root_node_

### DIFF
--- a/program_management/views/groupelementyear_read.py
+++ b/program_management/views/groupelementyear_read.py
@@ -85,7 +85,7 @@ def pdf_content(request, year, code, language):
         'created': datetime.datetime.now(),
         'max_block': tree.get_greater_block_value(),
         'main_part_col_length': get_main_part_col_length(tree.get_greater_block_value()),
-        'title': title
+        'title': title.strip()
     }
 
     with translation.override(language):


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-5627 vers QA