### PR TITLE
OSIS-5634 adapt permission if common for admission condition modifications

### DIFF
--- a/education_group/tests/views/admission_condition/test_common.py
+++ b/education_group/tests/views/admission_condition/test_common.py
@@ -1,0 +1,56 @@
+#
+#    OSIS stands for Open Student Information System. It's an application
+#    designed to manage the core business of higher education institutions,
+#    such as universities, faculties, institutes and professional schools.
+#    The core business involves the administration of students, teachers,
+#    courses, programs and so on.
+#
+#    Copyright (C) 2015-2021 Université catholique de Louvain (http://www.uclouvain.be)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU General Public License for more details.
+#
+#    A copy of this license - GNU General Public License - is available
+#    at the root of the source code of this program.  If not,
+#    see http://www.gnu.org/licenses/.
+#
+##############################################################################
+from django.test import TestCase
+
+from base.tests.factories.education_group_year import EducationGroupYearCommonBachelorFactory, \
+    EducationGroupYearBachelorFactory
+from education_group.views.admission_condition.common import AdmissionConditionMixin
+
+
+class TestPermissionRequiredMockClass(AdmissionConditionMixin):
+
+    def __init__(self, education_group_year_obj):
+        self.egy = education_group_year_obj
+
+    def get_permission_object(self):
+        return self.egy
+
+
+class TestPermissionRequired(TestCase):
+    def test_should_return_commonadmissioncondition_permission_when_education_group_year_is_common(self):
+        mock_instance = TestPermissionRequiredMockClass(EducationGroupYearCommonBachelorFactory())
+
+        self.assertEqual(
+            ('base.change_commonadmissioncondition', ),
+            mock_instance.get_permission_required()
+        )
+
+    def test_should_return_admissioncondition_permission_when_education_group_year_is_not_common(self):
+        mock_instance = TestPermissionRequiredMockClass(EducationGroupYearBachelorFactory())
+
+        self.assertEqual(
+            ('base.change_admissioncondition', ),
+            mock_instance.get_permission_required()
+        )

--- a/education_group/views/admission_condition/common.py
+++ b/education_group/views/admission_condition/common.py
@@ -29,6 +29,11 @@ from base.models.education_group_year import EducationGroupYear
 
 
 class AdmissionConditionMixin:
+    def get_permission_required(self):
+        if self.get_permission_object().is_common:
+            return ('base.change_commonadmissioncondition', )
+        return ('base.change_admissioncondition', )
+
     def get_admission_condition_object(self) -> 'AdmissionCondition':
         try:
             return AdmissionCondition.objects.get(

--- a/education_group/views/admission_condition/create.py
+++ b/education_group/views/admission_condition/create.py
@@ -38,10 +38,9 @@ from education_group.views.admission_condition.common import AdmissionConditionM
 from osis_role.contrib.views import PermissionRequiredMixin
 
 
-class CreateAdmissionConditionLine(SuccessMessageMixin, PermissionRequiredMixin, AjaxTemplateMixin,
-                                   AdmissionConditionMixin, CreateView):
+class CreateAdmissionConditionLine(SuccessMessageMixin, AdmissionConditionMixin, PermissionRequiredMixin,
+                                   AjaxTemplateMixin, CreateView):
     template_name = "education_group_app/admission_condition/line_edit.html"
-    permission_required = 'base.change_admissioncondition'
     raise_exception = True
     force_reload = True
     model = AdmissionConditionLine

--- a/education_group/views/admission_condition/delete.py
+++ b/education_group/views/admission_condition/delete.py
@@ -31,12 +31,12 @@ from base.business.education_groups.admission_condition import postpone_admissio
 from base.models.admission_condition import AdmissionConditionLine
 from base.views.common import display_success_messages
 from base.views.mixins import AjaxTemplateMixin
+from education_group.views.admission_condition.common import AdmissionConditionMixin
 from osis_role.contrib.views import PermissionRequiredMixin
 
 
-class DeleteAdmissionConditionLine(PermissionRequiredMixin, AjaxTemplateMixin, DeleteView):
+class DeleteAdmissionConditionLine(AdmissionConditionMixin, PermissionRequiredMixin, AjaxTemplateMixin, DeleteView):
     template_name = "education_group_app/admission_condition/line_delete.html"
-    permission_required = 'base.change_admissioncondition'
     raise_exception = True
     force_reload = True
     model = AdmissionConditionLine

--- a/education_group/views/admission_condition/order.py
+++ b/education_group/views/admission_condition/order.py
@@ -34,13 +34,13 @@ from base.business.education_groups.admission_condition import postpone_admissio
 from base.models.admission_condition import AdmissionConditionLine
 from base.views.mixins import AjaxTemplateMixin
 from education_group.forms.achievement import ActionForm
+from education_group.views.admission_condition.common import AdmissionConditionMixin
 from osis_role.contrib.views import PermissionRequiredMixin
 
 
-class OrderAdmissionConditionLine(SuccessMessageMixin, PermissionRequiredMixin, AjaxTemplateMixin, SingleObjectMixin,
-                                  FormView):
+class OrderAdmissionConditionLine(SuccessMessageMixin, AdmissionConditionMixin, PermissionRequiredMixin,
+                                  AjaxTemplateMixin, SingleObjectMixin, FormView):
     template_name = "education_group_app/admission_condition/line_order.html"
-    permission_required = 'base.change_admissioncondition'
     raise_exception = True
     force_reload = True
     model = AdmissionConditionLine

--- a/education_group/views/admission_condition/update.py
+++ b/education_group/views/admission_condition/update.py
@@ -32,6 +32,7 @@ from django.views.generic import FormView, UpdateView
 from base.business.education_groups.admission_condition import postpone_admission_condition, \
     can_postpone_admission_condition
 from base.models.admission_condition import AdmissionCondition, AdmissionConditionLine
+from base.models.education_group_year import EducationGroupYear
 from base.views.mixins import AjaxTemplateMixin
 from education_group.forms.admission_condition import UpdateTextForm, UpdateLineFrenchForm, \
     UpdateLineEnglishForm
@@ -39,15 +40,14 @@ from education_group.views.admission_condition.common import AdmissionConditionM
 from osis_role.contrib.views import PermissionRequiredMixin
 
 
-class UpdateAdmissionCondition(SuccessMessageMixin, PermissionRequiredMixin, AjaxTemplateMixin, AdmissionConditionMixin,
+class UpdateAdmissionCondition(SuccessMessageMixin, AdmissionConditionMixin, PermissionRequiredMixin, AjaxTemplateMixin,
                                FormView):
     template_name = "education_group_app/admission_condition/edit.html"
-    permission_required = "base.change_admissioncondition"
     form_class = UpdateTextForm
     raise_exception = True
     force_reload = True
 
-    def get_permission_object(self):
+    def get_permission_object(self) -> 'EducationGroupYear':
         return self.object.education_group_year
 
     def get_initial(self):
@@ -97,9 +97,9 @@ class UpdateAdmissionCondition(SuccessMessageMixin, PermissionRequiredMixin, Aja
         return 'text_' + self.get_section() + '_en'
 
 
-class UpdateAdmissionConditionLine(SuccessMessageMixin, PermissionRequiredMixin, AjaxTemplateMixin, UpdateView):
+class UpdateAdmissionConditionLine(SuccessMessageMixin, AdmissionConditionMixin, PermissionRequiredMixin,
+                                   AjaxTemplateMixin, UpdateView):
     template_name = "education_group_app/admission_condition/line_edit.html"
-    permission_required = 'base.change_admissioncondition'
     raise_exception = True
     force_reload = True
     model = AdmissionConditionLine


### PR DESCRIPTION
If the education group year is a common, we should check if the
user has the right to modifiy the admission condition with the
following permission: 'base.change_commonadmissioncondition'.
Otherwise the following permission is used:
'base.change_admissioncondition'.

Référence Jira : OSIS-5634

