### PR TITLE
OSIS-5649 : deprecated persist_tree

### DIFF
--- a/program_management/ddd/service/write/detach_node_service.py
+++ b/program_management/ddd/service/write/detach_node_service.py
@@ -30,7 +30,7 @@ from program_management.ddd import command
 from program_management.ddd.domain import link
 from program_management.ddd.domain.program_tree import PATH_SEPARATOR
 from program_management.ddd.domain.service import identity_search
-from program_management.ddd.repositories import persist_tree, program_tree
+from program_management.ddd.repositories import program_tree
 from program_management.ddd.repositories.tree_prerequisites import TreePrerequisitesRepository
 
 
@@ -47,7 +47,7 @@ def detach_node(detach_command: command.DetachNodeCommand) -> link.LinkIdentity:
     deleted_link = working_tree.detach_node(path_to_detach, program_tree_repository, TreePrerequisitesRepository())
 
     if commit:
-        persist_tree.persist(working_tree)
+        program_tree_repository.update(working_tree)
         publisher.element_detached.send(None, path_detached=path_to_detach)
 
     return deleted_link.entity_id

--- a/program_management/ddd/service/write/down_link_service.py
+++ b/program_management/ddd/service/write/down_link_service.py
@@ -25,7 +25,7 @@ from django.db import transaction
 
 from program_management.ddd import command
 from program_management.ddd.business_types import *
-from program_management.ddd.repositories import persist_tree, load_tree, load_node
+from program_management.ddd.repositories import load_tree, load_node, program_tree
 
 
 @transaction.atomic()
@@ -41,5 +41,5 @@ def down_link(command_up: command.OrderDownLinkCommand) -> 'NodeIdentity':
     parent_node = link_to_down.parent
     parent_node.down_child(child_node)
 
-    persist_tree.persist(tree)
+    program_tree.ProgramTreeRepository.update(tree)
     return child_node.entity_id

--- a/program_management/ddd/service/write/up_link_service.py
+++ b/program_management/ddd/service/write/up_link_service.py
@@ -24,7 +24,7 @@
 
 from program_management.ddd import command
 from program_management.ddd.business_types import *
-from program_management.ddd.repositories import load_node, load_tree, persist_tree
+from program_management.ddd.repositories import load_node, load_tree, program_tree
 
 
 def up_link(command_up: command.OrderUpLinkCommand) -> 'NodeIdentity':
@@ -39,5 +39,5 @@ def up_link(command_up: command.OrderUpLinkCommand) -> 'NodeIdentity':
     parent_node = link_to_up.parent
     parent_node.up_child(child_node)
 
-    persist_tree.persist(tree)
+    program_tree.ProgramTreeRepository.update(tree)
     return child_node.entity_id

--- a/program_management/tests/ddd/repositories/test_persist_tree.py
+++ b/program_management/tests/ddd/repositories/test_persist_tree.py
@@ -23,21 +23,18 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
-from unittest.mock import patch
 from unittest import mock
+from unittest.mock import patch
 
 from django.test import TestCase
 
 from base.models.group_element_year import GroupElementYear
-from base.models.prerequisite import Prerequisite
-from base.models.prerequisite_item import PrerequisiteItem
 from base.tests.factories.academic_year import AcademicYearFactory
 from base.tests.factories.group_element_year import GroupElementYearFactory, GroupElementYearChildLeafFactory
 from base.tests.factories.prerequisite import PrerequisiteFactory
 from base.tests.factories.prerequisite_item import PrerequisiteItemFactory
-from program_management.ddd.domain.node import NodeLearningUnitYear, NodeGroupYear
-from program_management.ddd.repositories import persist_tree, load_tree
-from program_management.ddd.validators._authorized_relationship import DetachAuthorizedRelationshipValidator
+from program_management.ddd.repositories import load_tree
+from program_management.ddd.repositories.program_tree import ProgramTreeRepository
 from program_management.ddd.validators.validators_by_business_action import DetachNodeValidatorList
 from program_management.tests.ddd.factories.link import LinkFactory
 from program_management.tests.ddd.factories.node import NodeLearningUnitYearFactory, NodeGroupYearFactory
@@ -79,7 +76,7 @@ class TestPersistTree(TestCase):
         tree.root_node.add_child(self.common_core_node)
         tree.root_node.children_as_nodes[0].add_child(self.learning_unit_year_node)
 
-        persist_tree.persist(tree)
+        ProgramTreeRepository.update(tree)
 
         link_root_with_common_core = GroupElementYear.objects.filter(
             parent_element_id=self.root_node.node_id,
@@ -100,7 +97,7 @@ class TestPersistTree(TestCase):
         # Append UE to common core
         tree.root_node.children[0].child.add_child(self.learning_unit_year_node)
 
-        persist_tree.persist(tree)
+        ProgramTreeRepository.update(tree)
 
         self.assertTrue(
             GroupElementYear.objects.filter(
@@ -113,7 +110,7 @@ class TestPersistTree(TestCase):
     def test_save_when_link_has_not_changed(self, mock):
         GroupElementYearFactory(parent_element=self.root_group, child_element=self.common_core_element)
         tree = load_tree.load(self.root_node.node_id)
-        persist_tree.persist(tree)
+        ProgramTreeRepository.update(tree)
         assertion_msg = "No changes made, so function GroupelementYear.save() should not have been called"
         self.assertFalse(mock.called, assertion_msg)
 
@@ -122,7 +119,7 @@ class TestPersistTree(TestCase):
         GroupElementYearFactory(parent_element=self.root_group, child_element=self.common_core_element)
         tree = load_tree.load(self.root_node.node_id)
         tree.root_node.children[0]._has_changed = True  # Made some changes
-        persist_tree.persist(tree)
+        ProgramTreeRepository.update(tree)
         assertion_msg = """
             Changes were triggered in the Link object, so function GroupelementYear.save() should have been called
         """
@@ -140,14 +137,14 @@ class TestPersistTree(TestCase):
 
         path_to_detach = "|".join([str(self.root_node.pk), str(node_to_detach.pk)])
         tree.detach_node(path_to_detach, mock.Mock(), mock.Mock())
-        persist_tree.persist(tree)
+        ProgramTreeRepository.update(tree)
         self.assertEqual(qs_link_will_be_detached.count(), 0)
 
     @patch("program_management.ddd.repositories.persist_tree.__delete_group_element_year")
     def test_delete_when_nothing_has_been_deleted(self, mock):
         GroupElementYearFactory(parent_element=self.root_group, child_element=self.common_core_element)
         tree = load_tree.load(self.root_node.node_id)
-        persist_tree.persist(tree)
+        ProgramTreeRepository.update(tree)
         assertion_msg = "No changes made, so function GroupelementYear.delete() should not have been called"
         self.assertFalse(mock.called, assertion_msg)
 
@@ -158,7 +155,7 @@ class TestPersistPrerequisites(TestCase):
         tree = ProgramTreeFactory()
         LinkFactory(parent=tree.root_node, child=NodeLearningUnitYearFactory())
 
-        persist_tree.persist(tree)
+        ProgramTreeRepository.update(tree)
 
         mock_persist_prerequisite.assert_called_once_with(tree)
 
@@ -201,7 +198,7 @@ class TestPersistPrerequisites(TestCase):
         root_node_child = tree.root_node.children_as_nodes[0]
         tree.root_node.detach_child(root_node_child)
 
-        persist_tree.persist(tree)
+        ProgramTreeRepository.update(tree)
         number_learning_unit_removed = 2
         self.assertNotEqual(
             mock_persist_prerequisite.call_count,

--- a/program_management/tests/ddd/service/test_detach_node_service.py
+++ b/program_management/tests/ddd/service/test_detach_node_service.py
@@ -25,10 +25,9 @@
 ##############################################################################
 from unittest.mock import patch
 
-from django.test import SimpleTestCase, TestCase
+from django.test import TestCase
 
 import osis_common.ddd.interface
-from base.ddd.utils import business_validator
 from base.models.enums.education_group_types import TrainingType
 from program_management.ddd.domain import program_tree
 from program_management.ddd.domain.program_tree import build_path, ProgramTree
@@ -67,9 +66,10 @@ class TestDetachNode(TestCase, ValidatorPatcherMixin):
         self._patch_load_trees_from_children()
 
     def _patch_persist_tree(self):
-        patcher_persist = patch("program_management.ddd.repositories.persist_tree.persist")
+        patcher_persist = patch("program_management.ddd.repositories.program_tree.ProgramTreeRepository.update")
         self.addCleanup(patcher_persist.stop)
         self.mock_persist = patcher_persist.start()
+        self.mock_persist.return_value = self.tree.entity_id
 
     def _patch_search_tree_identity(self):
         patcher_search_identity = patch("program_management.ddd.domain.service.identity_search."

--- a/program_management/tests/ddd/service/write/test_down_link_service.py
+++ b/program_management/tests/ddd/service/write/test_down_link_service.py
@@ -23,9 +23,9 @@
 # ############################################################################
 from unittest import mock
 
-from django.test import SimpleTestCase, TestCase
+from django.test import TestCase
 
-from program_management.ddd.domain import program_tree, link, node
+from program_management.ddd.domain import program_tree, node
 from program_management.ddd.service.write import down_link_service
 from program_management.tests.ddd.factories.commands.order_down_link_command import OrderDownLinkCommandFactory
 from program_management.tests.ddd.factories.link import LinkFactory
@@ -50,8 +50,8 @@ class TestDownLink(TestCase):
         self.addCleanup(self.load_tree_patcher.stop)
 
         self.persist_tree_patcher = mock.patch(
-            "program_management.ddd.repositories.persist_tree.persist",
-            return_value=None
+            "program_management.ddd.repositories.program_tree.ProgramTreeRepository.update",
+            return_value=self.tree.entity_id
         )
         self.mocked_persist_tree = self.persist_tree_patcher.start()
         self.addCleanup(self.persist_tree_patcher.stop)

--- a/program_management/tests/ddd/service/write/test_up_link_service.py
+++ b/program_management/tests/ddd/service/write/test_up_link_service.py
@@ -26,7 +26,7 @@ from unittest import mock
 from django.test import SimpleTestCase
 
 import program_management.ddd.service.write.up_link_service
-from program_management.ddd.domain import program_tree, link, node
+from program_management.ddd.domain import program_tree, node
 from program_management.tests.ddd.factories.commands.order_up_link_command import OrderUpLinkCommandFactory
 from program_management.tests.ddd.factories.link import LinkFactory
 from program_management.tests.ddd.factories.node import NodeGroupYearFactory, NodeLearningUnitYearFactory
@@ -50,8 +50,8 @@ class TestUpLink(SimpleTestCase):
         self.addCleanup(self.load_tree_patcher.stop)
 
         self.persist_tree_patcher = mock.patch(
-            "program_management.ddd.repositories.persist_tree.persist",
-            return_value=None
+            "program_management.ddd.repositories.program_tree.ProgramTreeRepository.update",
+            return_value=self.tree.entity_id
         )
         self.mocked_persist_tree = self.persist_tree_patcher.start()
         self.addCleanup(self.persist_tree_patcher.stop)

--- a/program_management/views/prerequisite_update.py
+++ b/program_management/views/prerequisite_update.py
@@ -33,7 +33,7 @@ from django.views.generic import FormView
 from base.ddd.utils.validation_message import MessageLevel
 from education_group.models.group_year import GroupYear
 from osis_role.contrib.views import PermissionRequiredMixin
-from program_management.ddd.repositories import persist_tree
+from program_management.ddd.repositories.program_tree import ProgramTreeRepository
 from program_management.ddd.validators._authorized_root_type_for_prerequisite import AuthorizedRootTypeForPrerequisite
 from program_management.forms.prerequisite import PrerequisiteForm
 from program_management.models.enums.node_type import NodeType
@@ -74,7 +74,7 @@ class LearningUnitPrerequisite(PermissionRequiredMixin, SuccessMessageMixin, Lea
         error_messages = [msg for msg in messages if msg.level == MessageLevel.ERROR]
         if error_messages:
             raise PermissionDenied([msg.message for msg in error_messages])
-        persist_tree.persist(self.program_tree)
+        ProgramTreeRepository.update(self.program_tree)
         return super().form_valid(form)
 
     def _get_learning_unit_year_node(self):


### PR DESCRIPTION
Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
