### PR TITLE
[hotfix/OSIS-5682 => QA] Le bouton réactualiser la publication ne fonctionne pas sur les mineures

### DIFF
--- a/program_management/ddd/domain/service/get_node_publish_url.py
+++ b/program_management/ddd/domain/service/get_node_publish_url.py
@@ -26,8 +26,8 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-from program_management.ddd.business_types import *
 from osis_common.ddd import interface
+from program_management.ddd.business_types import *
 
 
 class GetNodePublishUrl(interface.DomainService):
@@ -36,14 +36,5 @@ class GetNodePublishUrl(interface.DomainService):
         if not all([settings.ESB_API_URL, settings.ESB_REFRESH_PEDAGOGY_ENDPOINT]):
             raise ImproperlyConfigured('ESB_API_URL / ESB_REFRESH_PEDAGOGY_ENDPOINT must be set in configuration')
 
-        if node.is_minor():
-            code = "min-{}".format(node.code)
-        elif node.is_deepening():
-            code = "app-{}".format(node.code)
-        elif node.is_major():
-            code = "fsa1ba-{}".format(node.code)
-        else:
-            code = node.title
-
-        endpoint = settings.ESB_REFRESH_PEDAGOGY_ENDPOINT.format(year=node.year, code=code)
+        endpoint = settings.ESB_REFRESH_PEDAGOGY_ENDPOINT.format(year=node.year, code=node.title)
         return "{esb_api}/{endpoint}".format(esb_api=settings.ESB_API_URL, endpoint=endpoint)

--- a/program_management/tests/ddd/domain/service/test_get_node_publish_url.py
+++ b/program_management/tests/ddd/domain/service/test_get_node_publish_url.py
@@ -45,33 +45,6 @@ class TestGetNodePublishUrl(SimpleTestCase):
         with self.assertRaises(ImproperlyConfigured):
             GetNodePublishUrl.get_url_from_node(self.minor)
 
-    def test_assert_minor_publish_url(self):
-        code = "min-{}".format(self.minor.code)
-        expected_publish_url = "api.esb.com/offer/{year}/{code}/refresh".format(year=self.minor.year, code=code)
-
-        self.assertEqual(
-            GetNodePublishUrl.get_url_from_node(self.minor),
-            expected_publish_url
-        )
-
-    def test_assert_deepening_publish_url(self):
-        code = "app-{}".format(self.deepening.code)
-        expected_publish_url = "api.esb.com/offer/{year}/{code}/refresh".format(year=self.deepening.year, code=code)
-
-        self.assertEqual(
-            GetNodePublishUrl.get_url_from_node(self.deepening),
-            expected_publish_url
-        )
-
-    def test_assert_major_publish_url(self):
-        code = "fsa1ba-{}".format(self.major.code)
-        expected_publish_url = "api.esb.com/offer/{year}/{code}/refresh".format(year=self.major.year, code=code)
-
-        self.assertEqual(
-            GetNodePublishUrl.get_url_from_node(self.major),
-            expected_publish_url
-        )
-
     def test_assert_training_publish_url(self):
         code = self.training.title
         expected_publish_url = "api.esb.com/offer/{year}/{code}/refresh".format(year=self.training.year, code=code)


### PR DESCRIPTION
Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
