### PR TITLE
OSIS-5712 fix duplicate rows for external lu search

### DIFF
--- a/base/forms/learning_unit/search/external.py
+++ b/base/forms/learning_unit/search/external.py
@@ -170,7 +170,13 @@ class ExternalLearningUnitFilter(FilterSet):
             "learningcomponentyear_set"
         ).annotate(
             has_proposal=Exists(has_proposal)
-        ).order_by('academic_year__year', 'acronym')
+        ).order_by(
+            'academic_year__year',
+            'acronym'
+        ).distinct(  # Add distinct to protect against duplicate rows when filtering by country or city as the join with
+            'academic_year__year',  # entity version could create similar rows of different entity versions
+            'acronym'
+        )
 
         qs = LearningUnitYearQuerySet.annotate_full_title_class_method(qs)
         qs = LearningUnitYearQuerySet.annotate_entities_allocation_and_requirement_acronym(qs)


### PR DESCRIPTION
When filtering by country or city, duplicate rows appeared.
This is due to the fact that we do a join with entity and
entity version. An entity could potentially have more than
one version, thus leading to similar rows that differs only
by entity version.

Référence Jira : OSIS-5712

