### PR TITLE
OSIS-5731 : Correction du ruleset programmanager pour ajouter can_acc…

### DIFF
--- a/base/auth/roles/program_manager.py
+++ b/base/auth/roles/program_manager.py
@@ -86,6 +86,7 @@ class ProgramManager(EducationGroupRoleModel):
             'base.can_access_externallearningunityear': rules.always_allow,
             'base.can_access_learningunit': rules.always_allow,
             'base.can_access_offer': rules.always_allow,
+            'base.can_access_education_group': rules.always_allow,
             'base.can_access_student_path': rules.always_allow,
             'base.can_attach_node': osis_role_predicates.always_deny(
                 message=_("Program manager is not allowed to modify a link")


### PR DESCRIPTION
…ess_education_group

Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
