### PR TITLE
OSIS-4247 : Dans un email pouvoir colorer une ligne dans un tableau p…

### DIFF
--- a/assessments/tests/views/test_score_encoding.py
+++ b/assessments/tests/views/test_score_encoding.py
@@ -6,7 +6,7 @@
 #    The core business involves the administration of students, teachers,
 #    courses, programs and so on.
 #
-#    Copyright (C) 2015-2020 Université catholique de Louvain (http://www.uclouvain.be)
+#    Copyright (C) 2015-2021 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -302,12 +302,13 @@ class OnlineEncodingTest(MixinSetupOnlineEncoding, TestCase):
         self.client.post(url, data=self.get_form_with_all_students_filled())
 
         self.assertTrue(mock_send_email.called)
-        (persons, enrollments, learning_unit_acronym, offer_acronym), kwargs = mock_send_email.call_args
+        (persons, enrollments, learning_unit_acronym, offer_acronym, enrollment_ids), kwargs = mock_send_email.call_args
         self.assertEqual(persons, [self.tutor.person])
         self.assertEqual(enrollments, [self.enrollments[0]])
         self.assertEqual(learning_unit_acronym, self.learning_unit_year.acronym)
         education_group_year = self.enrollments[0].learning_unit_enrollment.offer_enrollment.education_group_year
         self.assertEqual(offer_acronym, education_group_year.acronym)
+        self.assertEqual(enrollment_ids[0], self.enrollments[0].id)
 
     @patch("base.utils.send_mail.send_message_after_all_encoded_by_manager")
     def test_email_after_encoding_all_students_for_education_group_year_with_justification(self, mock_send_email):
@@ -317,12 +318,13 @@ class OnlineEncodingTest(MixinSetupOnlineEncoding, TestCase):
         self.client.post(url, data=self.get_form_with_all_students_filled_and_one_with_justification_unjustified())
 
         self.assertTrue(mock_send_email.called)
-        (persons, enrollments, learning_unit_acronym, offer_acronym), kwargs = mock_send_email.call_args
+        (persons, enrollments, learning_unit_acronym, offer_acronym, enrollments_id), kwargs = mock_send_email.call_args
         self.assertEqual(persons, [self.tutor.person])
         self.assertEqual(enrollments, [self.enrollments[1]])
         self.assertEqual(learning_unit_acronym, self.learning_unit_year.acronym)
         education_group_year = self.enrollments[1].learning_unit_enrollment.offer_enrollment.education_group_year
         self.assertEqual(offer_acronym, education_group_year.acronym)
+        self.assertEqual(enrollments_id[0], self.enrollments[1].id)
 
     @patch("base.utils.send_mail.send_mail_after_scores_submission")
     def test_online_encoding_submission_not_all_encoded(self, mock_send_mail_after_scores_submission):

--- a/assessments/views/score_encoding.py
+++ b/assessments/views/score_encoding.py
@@ -6,7 +6,7 @@
 #    The core business involves the administration of students, teachers,
 #    courses, programs and so on.
 #
-#    Copyright (C) 2015-2019 Université catholique de Louvain (http://www.uclouvain.be)
+#    Copyright (C) 2015-2021 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -474,7 +474,8 @@ def __send_messages_for_each_education_group_year(
             learning_unit_year,
             education_group_year,
             pgm_manager=pgm_manager,
-            score_sheet_address=score_sheet_address
+            score_sheet_address=score_sheet_address,
+            updated_enrollments=updated_enrollments
         )
         if sent_error_message:
             sent_error_messages.append(sent_error_message)
@@ -486,7 +487,8 @@ def __send_message_for_education_group_year(
         learning_unit_year,
         education_group_year,
         pgm_manager: mdl.person.Person,
-        score_sheet_address: score_sheet_address_mdl.ScoreSheetAddress = None
+        score_sheet_address: score_sheet_address_mdl.ScoreSheetAddress = None,
+        updated_enrollments=None
 ):
     enrollments = filter_enrollments_by_education_group_year(all_enrollments, education_group_year)
     progress = mdl.exam_enrollment.calculate_exam_enrollment_progress(enrollments)
@@ -500,11 +502,13 @@ def __send_message_for_education_group_year(
         if score_sheet_address and score_sheet_address.email:
             # Todo: Refactor CC list must not be a person but a list of email...
             cc_list.append(Person(email=score_sheet_address.email))
+        updated_enrollments_ids = [enrollment.id for enrollment in updated_enrollments]
         sent_error_message = send_mail.send_message_after_all_encoded_by_manager(
             receivers,
             enrollments,
             learning_unit_year.acronym,
             offer_acronym,
+            updated_enrollments_ids,
             cc=cc_list
         )
     return sent_error_message

--- a/base/locale/en/LC_MESSAGES/django.po
+++ b/base/locale/en/LC_MESSAGES/django.po
@@ -2717,6 +2717,9 @@ msgstr ""
 msgid "Update for teacher unlocked"
 msgstr ""
 
+msgid "Updated"
+msgstr ""
+
 msgid "Url"
 msgstr ""
 

--- a/base/locale/fr_BE/LC_MESSAGES/django.po
+++ b/base/locale/fr_BE/LC_MESSAGES/django.po
@@ -2822,6 +2822,9 @@ msgstr "Mise-à-jour bloquée pour l'enseignant"
 msgid "Update for teacher unlocked"
 msgstr "Mise-à-jour débloquée pour l'enseignant"
 
+msgid "Updated"
+msgstr "Mis-à-jour"
+
 msgid "Url"
 msgstr "URL"
 

--- a/base/tests/utils/test_send_mail.py
+++ b/base/tests/utils/test_send_mail.py
@@ -6,7 +6,7 @@
 #    The core business involves the administration of students, teachers,
 #    courses, programs and so on.
 #
-#    Copyright (C) 2015-2020 Université catholique de Louvain (http://www.uclouvain.be)
+#    Copyright (C) 2015-2021 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -157,21 +157,24 @@ class TestSendMessage(TestCase):
             [self.person_1, self.person_without_language],
             [self.exam_enrollment_1],
             self.learning_unit_year.acronym,
-            self.educ_group_year.acronym
+            self.educ_group_year.acronym,
+            [self.exam_enrollment_1.id]
         )
         args = mock_create_table.call_args[0]
         self.assertEqual(args[0], 'enrollments')
 
         self.assertListEqual(
-            list(args[2][0]),
-            [self.exam_enrollment_1.learning_unit_enrollment.offer_enrollment.education_group_year.acronym,
-             self.exam_enrollment_1.session_exam.number_session,
-             self.exam_enrollment_1.learning_unit_enrollment.offer_enrollment.student.registration_id,
-             self.exam_enrollment_1.learning_unit_enrollment.offer_enrollment.student.person.last_name,
-             self.exam_enrollment_1.learning_unit_enrollment.offer_enrollment.student.person.first_name,
-             self.exam_enrollment_1.score_final if self.exam_enrollment_1.score_final else '',
-             self.exam_enrollment_1.justification_final if self.exam_enrollment_1.justification_final else '',
-             ])
+            list(args[2]['data'][0]),
+            [
+                self.exam_enrollment_1.learning_unit_enrollment.offer_enrollment.education_group_year.acronym,
+                self.exam_enrollment_1.session_exam.number_session,
+                self.exam_enrollment_1.learning_unit_enrollment.offer_enrollment.student.registration_id,
+                self.exam_enrollment_1.learning_unit_enrollment.offer_enrollment.student.person.last_name,
+                self.exam_enrollment_1.learning_unit_enrollment.offer_enrollment.student.person.first_name,
+                self.exam_enrollment_1.score_final if self.exam_enrollment_1.score_final else '',
+                self.exam_enrollment_1.justification_final if self.exam_enrollment_1.justification_final else '',
+            ]
+        )
         args = mock_send_messages.call_args[0][0]
         self.assertEqual(self.learning_unit_year.acronym, args.get('subject_data').get('learning_unit_acronym'))
         self.assertEqual(self.educ_group_year.acronym, args.get('subject_data').get('offer_acronym'))
@@ -243,7 +246,9 @@ class TestSendMessage(TestCase):
         self.assertListEqual(expected, send_mail.get_enrollment_headers('fr-be'))
 
     def test_check_table_headers_en(self):
-        expected = ['Program', 'Session number', 'Registration number', 'Last name', 'First name', 'Score', 'Justification']
+        expected = [
+            'Program', 'Session number', 'Registration number', 'Last name', 'First name', 'Score', 'Justification'
+        ]
         self.assertListEqual(expected, send_mail.get_enrollment_headers('en'))
 
 

--- a/base/utils/send_mail.py
+++ b/base/utils/send_mail.py
@@ -6,7 +6,7 @@
 #    The core business involves the administration of students, teachers,
 #    courses, programs and so on.
 #
-#    Copyright (C) 2015-2020 Université catholique de Louvain (http://www.uclouvain.be)
+#    Copyright (C) 2015-2021 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -273,7 +273,14 @@ def _build_worksheet_parameters(workbook, a_user, operation, research_criteria):
     return worksheet_parameters
 
 
-def send_message_after_all_encoded_by_manager(receivers, enrollments, learning_unit_acronym, offer_acronym, cc=None):
+def send_message_after_all_encoded_by_manager(
+        receivers,
+        enrollments,
+        learning_unit_acronym,
+        offer_acronym,
+        updated_enrollments_ids,
+        cc=None
+):
     """
     Send a message to all tutor from a learning unit when all scores are submitted by program manager
     :param receivers: The list of the tutor (person) of the learning unit
@@ -281,6 +288,7 @@ def send_message_after_all_encoded_by_manager(receivers, enrollments, learning_u
     :param learning_unit_acronym The learning unit encoded
     :param offer_acronym: The offer which is managed
     :param cc: Persons (list) need to be in copy (cc) of the emails sent
+    :param updated_enrollments_ids: updated enrollments ids
     :return: A message if an error occurred, None if it's ok
     """
 
@@ -309,12 +317,28 @@ def send_message_after_all_encoded_by_manager(receivers, enrollments, learning_u
 
     receivers_by_lang = itertools.groupby(sorted(receivers, key=__order_by_lang), __order_by_lang)
 
+    rows_styles = None
+    txt_complementary_first_col_content_data = None
+    if len(enrollments) > 1 and len(updated_enrollments_ids) == len(enrollments):
+        rows_styles = _html_format_rows_styles(enrollments, updated_enrollments_ids)
+        txt_complementary_first_col_content_data = _txt_format_complementary_row_content(
+            enrollments,
+            updated_enrollments_ids
+        )
+
     for receiver_lang, receivers in receivers_by_lang:
         receivers = list(receivers)
         table = message_config.create_table(
             'enrollments',
             get_enrollment_headers(receiver_lang),
-            enrollments_data,
+            {
+                "style": rows_styles,
+                "data": enrollments_data,
+                "txt_complementary_first_col": {
+                    "header": _("Updated"),
+                    "rows_content": txt_complementary_first_col_content_data
+                }
+            },
             data_translatable=['Justification'],
         )
 
@@ -341,7 +365,7 @@ def build_scores_sheet_attachment(list_exam_enrollments):
     mimetype = "application/pdf"
     content = paper_sheet.build_pdf(
         score_encoding_sheet.scores_sheet_data(list_exam_enrollments, tutor=None))
-    return (name, content, mimetype)
+    return name, content, mimetype
 
 
 def send_mail_for_educational_information_update(teachers, learning_units_years):
@@ -372,3 +396,20 @@ def _get_encoding_status(language, all_encoded):
     message = 'All the scores are encoded.' if all_encoded else 'It remains notes to encode.'
     with translation.override(language):
         return translation.gettext(message)
+
+
+def _html_format_rows_styles(enrollments: List[ExamEnrollment], updated_enrollments_ids: List[int]) -> List[str]:
+    css_style_on_rows = []
+    for enrollment in enrollments:
+        css_style_on_rows.append('background-color: lime;' if enrollment.id in updated_enrollments_ids else '')
+    return css_style_on_rows
+
+
+def _txt_format_complementary_row_content(
+        enrollments: List[ExamEnrollment],
+        updated_enrollments_ids: List[int]
+) -> List[str]:
+    complementary_first_cols_contents = []
+    for enrollment in enrollments:
+        complementary_first_cols_contents.append('*' if enrollment.id in updated_enrollments_ids else '')
+    return complementary_first_cols_contents


### PR DESCRIPTION
…our le format html. Pouvoir ajouter une colonne avant la première colonne pour y indiquer une specification (pour faire l'+/- l'équivalent de la coloration dans le format html)

Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
