### PR TITLE
[hotfix/OSIS-5803 => QA] Acteurs académiques > Désignation des gestionnaires de parcours > le type de formation et l_entité sont toujours vides

### DIFF
--- a/assessments/templates/admin/pgm_manager.html
+++ b/assessments/templates/admin/pgm_manager.html
@@ -129,8 +129,8 @@
                                                            onclick="load_managers()">
                                                 </td>
                                                 <td>{{ pgm.acronym }}</td>
-                                                <td>{{ pgm.education_group_type.get_name_verbose | default_if_none:'' }}</td>
-                                                <td>{{ pgm.management_entity.acronym }}</td>
+                                                <td>{{ pgm.education_group_type }}</td>
+                                                <td>{{ pgm.management_entity }}</td>
                                             </tr>
                                         {% endfor %}
                                     </table>


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-5803 vers QA