### PR TITLE
[hotfix/OSIS-5836 => QA] onglet « infos générales » des mineures n_est plus modifiable

### DIFF
--- a/education_group/views/mini_training/general_information_read.py
+++ b/education_group/views/mini_training/general_information_read.py
@@ -55,7 +55,7 @@ class MiniTrainingReadGeneralInformation(MiniTrainingRead):
             "?path={}".format(self.get_path()),
             "can_edit_information":
                 self.request.user.has_perm(
-                    "base.base.change_minitraining_pedagogyinformation",
+                    "base.change_minitraining_pedagogyinformation",
                     self.get_education_group_version().offer
                 ),
             "show_contacts": self.can_have_contacts(),


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-5836 vers QA