### PR TITLE
OSIS-5882  base.can_access_class -> learning_unit.view_learningclassyear (use default model perm)

### DIFF
--- a/base/auth/roles/program_manager.py
+++ b/base/auth/roles/program_manager.py
@@ -116,7 +116,7 @@ class ProgramManager(EducationGroupRoleModel):
                 message=_("Program manager is not allowed to modify a specific version")
             ),
             'base.view_publish_btn': rules.always_deny,
-            'base.can_access_class': rules.always_allow,
+            'learning_unit.view_learningclassyear': rules.always_allow,
         })
 
 

--- a/base/fixtures/groups.json
+++ b/base/fixtures/groups.json
@@ -364,8 +364,8 @@
                     "structure"
                 ],
                 [
-                    "can_access_class",
-                    "base",
+                    "view_learningclassyear",
+                    "learning_unit",
                     "learningclassyear"
                 ]
             ]

--- a/base/templates/learning_unit/components.html
+++ b/base/templates/learning_unit/components.html
@@ -136,11 +136,11 @@
                     {% url 'class_identification' learning_unit_year.academic_year.year learning_unit_year.acronym learning_class_year.acronym as class_identification_url %}
                     <tr class="class_year collapse collapse_classes{{ component_number }}">
                         <td colspan="1">
-                            {% a_tag_has_perm class_identification_url learning_class_year.used_by_learning_units_year 'base.can_access_class' user %}
+                            {% a_tag_has_perm class_identification_url learning_class_year.used_by_learning_units_year 'learning_unit.view_learningclassyear' user %}
                         </td>
                         <td colspan="2">
                             {% with "/ "|add:component.learning_component_year.type_letter_acronym|add:" - "|add:learning_class_year.acronym as class_code %}
-                                {% a_tag_has_perm class_identification_url class_code 'base.can_access_class' user %}
+                                {% a_tag_has_perm class_identification_url class_code 'learning_unit.view_learningclassyear' user %}
                             {% endwith %}
                         </td>
                         <td colspan="6">

--- a/learning_unit/auth/roles/central_manager.py
+++ b/learning_unit/auth/roles/central_manager.py
@@ -147,5 +147,5 @@ class CentralManager(osis_role_models.EntityRoleModel):
                 osis_role_predicates.always_deny(
                     message=_('Classes can only be created by a faculty manager')
                 ),
-            'base.can_access_class': rules.always_allow,
+            'learning_unit.view_learningclassyear': rules.always_allow,
          })

--- a/learning_unit/auth/roles/faculty_manager.py
+++ b/learning_unit/auth/roles/faculty_manager.py
@@ -148,5 +148,5 @@ class FacultyManager(osis_role_models.EntityRoleModel):
             'base.can_create_class':
                 predicates.is_user_attached_to_current_requirement_entity &
                 predicates.is_learning_unit_year_older_or_equals_than_limit_settings_year,
-            'base.can_access_class': rules.always_allow,
+            'learning_unit.view_learningclassyear': rules.always_allow,
         })

--- a/learning_unit/views/learning_unit_class/identification_read.py
+++ b/learning_unit/views/learning_unit_class/identification_read.py
@@ -42,7 +42,7 @@ from learning_unit.models.learning_class_year import LearningClassYear
 
 class ClassIdentificationView(PermissionRequiredMixin, TemplateView):
     template_name = "class/identification_tab.html"
-    permission_required = 'base.can_access_class'
+    permission_required = 'learning_unit.view_learningclassyear'
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Référence Jira : OSIS-5882

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
