### PR TITLE
correction-contenu-json-candidature : Modification du contenu du json…

### DIFF
--- a/infrastructure/application/serializer/application.py
+++ b/infrastructure/application/serializer/application.py
@@ -38,7 +38,7 @@ class ApplicationSerializer:
             'practical_allocation': str(application.practical_volume) if application.practical_volume else '0',
             'learning_container_year': {
                 'reference': self._get_reference(application),
-                'year': str(application.vacant_course_id.year),
+                'year': application.vacant_course_id.year,
                 'acronym': application.vacant_course_id.code
             }
         }
@@ -53,7 +53,7 @@ class ApplicationSerializer:
             'practical_allocation': str(application.practical_volume) if application.practical_volume else '0',
             'learning_container_year': {
                 'reference': self._get_reference(application),
-                'year': str(application.vacant_course_id.year),
+                'year': application.vacant_course_id.year,
                 'acronym': application.vacant_course_id.code
             }
         }

--- a/infrastructure/application/test/serializer/test_application.py
+++ b/infrastructure/application/test/serializer/test_application.py
@@ -73,7 +73,7 @@ class ApplicationSerializerTest(TestCase):
 
         self.assertEqual(obj_serialized['learning_container_year']['reference'], '428750')
         self.assertEqual(
-            obj_serialized['learning_container_year']['year'], str(self.application.vacant_course_id.year)
+            obj_serialized['learning_container_year']['year'], self.application.vacant_course_id.year
         )
         self.assertEqual(
             obj_serialized['learning_container_year']['acronym'], str(self.application.vacant_course_id.code)
@@ -91,7 +91,7 @@ class ApplicationSerializerTest(TestCase):
 
         self.assertEqual(obj_serialized['learning_container_year']['reference'], '428750')
         self.assertEqual(
-            obj_serialized['learning_container_year']['year'], str(self.application.vacant_course_id.year)
+            obj_serialized['learning_container_year']['year'], self.application.vacant_course_id.year
         )
         self.assertEqual(
             obj_serialized['learning_container_year']['acronym'], str(self.application.vacant_course_id.code)


### PR DESCRIPTION
… pour le delete/update d'une candidature.  Le year n'est plus un string, mais bien un int

Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
