### PR TITLE
[hotfix/OSIS-6064 => QA] UE > On ne voit plus la liste des anac sur les onglets Composants, Fiche desc., cahier des charges, Utilisations, Enseignant.e.s

### DIFF
--- a/base/views/learning_units/common.py
+++ b/base/views/learning_units/common.py
@@ -144,6 +144,7 @@ def get_common_context_learning_unit_year(person,
         'learning_unit_year': learning_unit_year,
         'current_academic_year': mdl.academic_year.starting_academic_year(),
         'is_person_linked_to_entity': person.is_linked_to_entity_in_charge_of_learning_unit_year(learning_unit_year),
+        'learning_unit_year_choices': (reversed(learning_unit_year.learning_unit.learningunityear_set.all()),),
     }
 
 


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-6064 vers QA