### PR TITLE
Move osis-document urls under API to bypass shibboleth

### DIFF
--- a/backoffice/settings/base.py
+++ b/backoffice/settings/base.py
@@ -224,7 +224,7 @@ MEDIA_URL = os.environ.get('MEDIA_URL',  '/media/')
 CONTENT_TYPES = ['application/csv', 'application/doc', 'application/pdf', 'application/xls', 'application/xml',
                  'application/zip', 'image/jpeg', 'image/gif', 'image/png', 'text/html', 'text/plain']
 MAX_UPLOAD_SIZE = int(os.environ.get('MAX_UPLOAD_SIZE', 5242880))
-OSIS_DOCUMENT_BASE_URL = os.environ.get('OSIS_DOCUMENT_BASE_URL', '/osis_document/')
+OSIS_DOCUMENT_BASE_URL = os.environ.get('OSIS_DOCUMENT_BASE_URL', '')
 
 # Logging settings
 # Logging framework is defined in env settings (ex: dev.py)

--- a/backoffice/urls.py
+++ b/backoffice/urls.py
@@ -78,7 +78,7 @@ if 'osis_signature' in settings.INSTALLED_APPS:
     urlpatterns += (url(r'^osis_signature/', include('osis_signature.urls')),)
 if 'osis_document' in settings.INSTALLED_APPS:
     urlpatterns += (
-        url(r'^osis-document/', include('osis_document.urls')),
+        url(r'^api/osis-document/', include('osis_document.urls')),
     )
 if 'osis_notification' in settings.INSTALLED_APPS:
     urlpatterns += (


### PR DESCRIPTION
Vérifier les points suivants : 
- [x] Modifier OSIS_DOCUMENT_BASE_URL dans les déploiements (ex : `https://dev.osis.uclouvain.be/api/osis-document/` avec le slash de fin)
  - [x] dev, test, qa, prod
    - [x] sur osis
    - [x] sur osis-portal
  - [x] sur les déploiements de branche
    - [x] sur osis
    - [x] sur osis-portal
- [x] Vérifier la présence de OSIS_DOCUMENT_DOMAIN_LIST ( ex: `['https://dev.studies.uclouvain.be']`) dans les déploiements
  - [x] dev, test, qa, prod
    - [x] sur osis
  - [x] sur les déploiements de branche
    - [x] sur osis


