### PR TITLE
[feature/OSIS-6177 => DEV] En tant que gestionnaire central ou facultaire, je veux que l_anac par défaut pour la recherche des UE à ajouter dans l_arbre soit celle de l_arbre pour éviter la confusion chez les gestionnaires

### DIFF
--- a/program_management/views/quick_search.py
+++ b/program_management/views/quick_search.py
@@ -1,11 +1,11 @@
-# ############################################################################
+#############################################################################
 #  OSIS stands for Open Student Information System. It's an application
 #  designed to manage the core business of higher education institutions,
 #  such as universities, faculties, institutes and professional schools.
 #  The core business involves the administration of students, teachers,
 #  courses, programs and so on.
 #
-#  Copyright (C) 2015-2019 Université catholique de Louvain (http://www.uclouvain.be)
+#  Copyright (C) 2015-2021 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -183,7 +183,7 @@ class QuickSearchLearningUnitYearView(PermissionRequiredMixin, CacheFilterMixin,
         queryparams = kwargs['data'].copy()
         del queryparams["path"]
         if "academic_year" not in queryparams:
-            queryparams["academic_year"] = self.kwargs["year"]
+            queryparams["academic_year__year"] = self.kwargs["year"]
         kwargs["data"] = queryparams
         return kwargs
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 coverage==5.5
-Django==2.2.13
+Django==2.2.24
 pika==0.12.0
 openpyxl==2.3.2
-Pillow==7.2.0
+Pillow==8.3.2
 psycopg2-binary==2.7.5
 reportlab==3.5.34
 django-analytical==2.4.0
@@ -26,7 +26,7 @@ python-magic==0.4.15
 django-ajax-selects==1.7.1
 celery==4.4.7
 django-celery-beat==1.5.0
-django-celery-results==1.1.2
+django-celery-results==1.2.1
 django-filter==2.2.0
 django-hijack==2.1.10
 django-hijack-admin==2.1.10


### PR DESCRIPTION
Pull request automatique de feature/OSIS-6177 vers DEV