### PR TITLE
[feature/OSIS-6254 => DEV] En tant que gestionnaire de parcours étudiant ou DAF, je veux voir la rubrique pour accéder au module de désignation des responsables de notes quand les périodes d_encodage des notes sont fermées pour mieux comprendre pourquoi le module est inaccessible

### DIFF
--- a/assessments/templates/assessments/score_responsible/score_responsibles.html
+++ b/assessments/templates/assessments/score_responsible/score_responsibles.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% load static bootstrap3 i18n %}
+{% load static bootstrap3 i18n perms %}
 
 {% comment "License" %}
  * OSIS stands for Open Student Information System. It's an application
@@ -32,46 +32,58 @@
 {% endblock %}
 
 {% block content %}
-     <div class="page-header">
-        <h2>{% trans 'Scores responsibles' %} - {{ filter.academic_year }}</h2>
-    </div>
-    <div class="panel panel-default">
-        <div class="panel-heading">
-             <form id="search_form" method="GET">
-                 <div class="row">
-                    {% bootstrap_field filter.form.acronym form_group_class="col-md-1" %}
-                    {% bootstrap_field filter.form.learning_unit_title form_group_class="col-md-3" %}
-                    {% bootstrap_field filter.form.tutor form_group_class="col-md-3" %}
-                    {% bootstrap_field filter.form.scores_responsible form_group_class="col-md-2" %}
-                    {% bootstrap_field filter.form.requirement_entity form_group_class="col-md-1" %}
-                    {% bootstrap_field filter.form.with_entity_subordinated form_group_class="col-md-1" %}
-                    {% bootstrap_field filter.form.ordering %}
-                    <div class="col-md-1 form-group" style="margin-top:25px">
-                        <button type="submit" id="bt_submit_search" class="btn btn-primary" role="button"
-                                title="{% trans 'Search' %}">
-                            <span class="glyphicon glyphicon-search"></span>
-                        </button>
-                    </div>
-                 </div>
-             </form>
+    {% view_scores_responsible as can_view_scores_responsible %}
+    {% if not can_view_scores_responsible and session_messages %}
+        <div class="alert-warning">
+            <ul>
+                {% for message in session_messages %}
+                    <li>{{ message }}</li>
+                {% endfor %}
+            </ul>
         </div>
-         <div class="panel-body">
-            <table id="tb_scores_responsible" class="table table-striped table-hover">
-                <thead>
-                    <tr>
-                        <th>{% trans 'Entity' %}</th>
-                        <th>{% trans 'Code' %}</th>
-                        <th>{% trans 'Title' %}</th>
-                        <th>{% trans 'Tutor' %}</th>
-                        <th></th>
-                    </tr>
-                </thead>
-            </table>
-            <div class="text-center">
-                {% bootstrap_pagination page_obj extra=request.GET.urlencode %}
+    {% endif %}
+    <div class="page-header">
+        <h2>{% trans 'Scores responsibles' %}{% if filter.academic_year %} - {{ filter.academic_year }}{% endif %}</h2>
+    </div>
+    {% if can_view_scores_responsible %}
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                 <form id="search_form" method="GET">
+                     <div class="row">
+                        {% bootstrap_field filter.form.acronym form_group_class="col-md-1" %}
+                        {% bootstrap_field filter.form.learning_unit_title form_group_class="col-md-3" %}
+                        {% bootstrap_field filter.form.tutor form_group_class="col-md-3" %}
+                        {% bootstrap_field filter.form.scores_responsible form_group_class="col-md-2" %}
+                        {% bootstrap_field filter.form.requirement_entity form_group_class="col-md-1" %}
+                        {% bootstrap_field filter.form.with_entity_subordinated form_group_class="col-md-1" %}
+                        {% bootstrap_field filter.form.ordering %}
+                        <div class="col-md-1 form-group" style="margin-top:25px">
+                            <button type="submit" id="bt_submit_search" class="btn btn-primary" role="button"
+                                    title="{% trans 'Search' %}">
+                                <span class="glyphicon glyphicon-search"></span>
+                            </button>
+                        </div>
+                     </div>
+                 </form>
+            </div>
+             <div class="panel-body">
+                <table id="tb_scores_responsible" class="table table-striped table-hover">
+                    <thead>
+                        <tr>
+                            <th>{% trans 'Entity' %}</th>
+                            <th>{% trans 'Code' %}</th>
+                            <th>{% trans 'Title' %}</th>
+                            <th>{% trans 'Tutor' %}</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                </table>
+                <div class="text-center">
+                    {% bootstrap_pagination page_obj extra=request.GET.urlencode %}
+                </div>
             </div>
         </div>
-    </div>
+    {% endif %}
 {% endblock %}
 
 {% block script %}

--- a/assessments/tests/views/test_scores_responsible.py
+++ b/assessments/tests/views/test_scores_responsible.py
@@ -6,7 +6,7 @@
 #    The core business involves the administration of students, teachers,
 #    courses, programs and so on.
 #
-#    Copyright (C) 2015-2019 Université catholique de Louvain (http://www.uclouvain.be)
+#    Copyright (C) 2015-2012 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -129,13 +129,6 @@ class ScoresResponsibleSearchTestCase(TestCase):
         response = self.client.get(self.url)
 
         self.assertRedirects(response, "/login/?next={}".format(self.url))
-
-    def test_case_user_without_perms(self):
-        unauthorized_user = UserFactory()
-        self.client.force_login(unauthorized_user)
-
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, HttpResponseForbidden.status_code)
 
     def test_case_search_without_filter_ensure_ordering(self):
         data = {

--- a/assessments/views/score_encoding.py
+++ b/assessments/views/score_encoding.py
@@ -78,33 +78,37 @@ def assessments(request):
 @permission_required('assessments.can_access_scoreencoding', raise_exception=True)
 @user_passes_test(_is_not_inside_scores_encodings_period, login_url=reverse_lazy('assessments'))
 def outside_period(request):
-    date_format = str(_('date_format'))
-    latest_session_exam = mdl.session_exam_calendar.get_latest_session_exam()
-    closest_new_session_exam = mdl.session_exam_calendar.get_closest_new_session_exam()
+    messages_str = get_latest_closest_session_information_message()
 
-    if latest_session_exam:
-        month_session = latest_session_exam.month_session_name()
-        str_date = latest_session_exam.end_date.strftime(date_format)
+    for message in messages_str:
         messages.add_message(
             request,
             messages.WARNING,
-            _("The period of scores' encoding for %(month_session)s session is closed since %(str_date)s")
-            % {'month_session': month_session, 'str_date': str_date}
-        )
-
-    if closest_new_session_exam:
-        month_session = closest_new_session_exam.month_session_name()
-        str_date = closest_new_session_exam.start_date.strftime(date_format)
-        messages.add_message(
-            request,
-            messages.WARNING,
-            _("The period of scores' encoding for %(month_session)s session will be open %(str_date)s")
-            % {'month_session': month_session, 'str_date': str_date}
+            message
         )
 
     if not messages.get_messages(request):
         messages.add_message(request, messages.WARNING, _("The period of scores' encoding is not opened"))
     return render(request, "assessments/outside_scores_encodings_period.html", {})
+
+
+def get_latest_closest_session_information_message():
+    messages_str = []
+    date_format = str(_('date_format'))
+    latest_session_exam = mdl.session_exam_calendar.get_latest_session_exam()
+    closest_new_session_exam = mdl.session_exam_calendar.get_closest_new_session_exam()
+    if latest_session_exam:
+        month_session = latest_session_exam.month_session_name()
+        str_date = latest_session_exam.end_date.strftime(date_format)
+        messages_str.append(
+            _("The period of scores' encoding for %(month_session)s session is closed since %(str_date)s")
+            % {'month_session': month_session, 'str_date': str_date})
+    if closest_new_session_exam:
+        month_session = closest_new_session_exam.month_session_name()
+        str_date = closest_new_session_exam.start_date.strftime(date_format)
+        messages_str.append(_("The period of scores' encoding for %(month_session)s session will be open %(str_date)s")
+                            % {'month_session': month_session, 'str_date': str_date})
+    return messages_str
 
 
 class LearningUnitScoreEncodingView(LoginRequiredMixin, View):

--- a/base/business/perms.py
+++ b/base/business/perms.py
@@ -30,3 +30,7 @@ def view_academicactors(user):
     return user.has_perm('base.view_programmanager') \
            or ("assessments" in settings.INSTALLED_APPS and user.has_perm('assessments.view_scoresresponsible')) \
            or ("dissertation" in settings.INSTALLED_APPS and user.has_perm('dissertation.change_offerproposition'))
+
+
+def view_scores_responsible(user):
+    return "assessments" in settings.INSTALLED_APPS and user.has_perm('assessments.view_scoresresponsible')

--- a/base/templates/academic_actors.html
+++ b/base/templates/academic_actors.html
@@ -48,15 +48,13 @@
                     </div>
                 {% endif %}
 
-                {% if "assessments" in installed_apps and perms.assessments.view_scoresresponsible %}
-                    <div class="col-md-1"><i class="fa fa-users" style="font-size: 400%; color: #6699FF;"></i></div>
-                    <div class="col-md-5">
-                        <h4 class="media-heading">
-                            <a href="{% url 'scores_responsibles_search' %}" id="lnk_srm_managers">{% trans 'Scores responsibles' %}</a>
-                        </h4>
-                        <p>{% trans 'Management of the scores responsibles managers' %}</p>
-                    </div>
-                {% endif %}
+                <div class="col-md-1"><i class="fa fa-users" style="font-size: 400%; color: #6699FF;"></i></div>
+                <div class="col-md-5">
+                    <h4 class="media-heading">
+                        <a href="{% url 'scores_responsibles_search' %}" id="lnk_srm_managers">{% trans 'Scores responsibles' %}</a>
+                    </h4>
+                    <p>{% trans 'Management of the scores responsibles managers' %}</p>
+                </div>
             </div>
             <br>
             {% if "dissertation" in installed_apps and perms.dissertation.change_offerproposition %}

--- a/base/templates/blocks/navbar_top.html
+++ b/base/templates/blocks/navbar_top.html
@@ -133,15 +133,12 @@
                                         </a>
                                     </li>
                                 {% endif %}
-                                {% view_academicactors as can_view_academicactors %}
-                                {% if can_view_academicactors %}
-                                    <li>
-                                        <a href="{% url 'academic_actors' %}" id="lnk_dropdown_academic actors">
-                                            <span class="fa fa-users"></span>
-                                            {% trans 'Academic actors' %}
-                                        </a>
-                                    </li>
-                                {% endif %}
+                                <li>
+                                    <a href="{% url 'academic_actors' %}" id="lnk_dropdown_academic actors">
+                                        <span class="fa fa-users"></span>
+                                        {% trans 'Academic actors' %}
+                                    </a>
+                                </li>
                                 {% if perms.base.can_access_academicyear and perms.base.can_access_academic_calendar %}
                                     <li>
                                         <a href="{% url 'academic_calendars' %}" id="lnk_academic_calendars">

--- a/base/templates/institution.html
+++ b/base/templates/institution.html
@@ -54,13 +54,11 @@
         </div>
         <br/>
         <div class="row">
-            {% if view_academicactors %}
-                <div class="col-md-1"><i class="fa fa-users" style="font-size: 400%; color: #6699FF;"></i></div>
-                <div class="col-md-5">
-                    <h4 class="media-heading"><a href="{% url 'academic_actors' %}" id="lnk_academic_actors">{% trans 'Academic actors'%}</a></h4>
-                    <p>{% trans 'Academic actors management' %}</p>
-                </div>
-            {% endif %}
+            <div class="col-md-1"><i class="fa fa-users" style="font-size: 400%; color: #6699FF;"></i></div>
+            <div class="col-md-5">
+                <h4 class="media-heading"><a href="{% url 'academic_actors' %}" id="lnk_academic_actors">{% trans 'Academic actors'%}</a></h4>
+                <p>{% trans 'Academic actors management' %}</p>
+            </div>
             {%  if perms.base.can_access_academicyear and perms.base.can_access_academic_calendar %}
                 <div class="col-md-1"><i class="fa fa-calendar" style="font-size: 400%; color: #6699FF;"></i></div>
                 <div class="col-md-5">

--- a/base/templatetags/perms.py
+++ b/base/templatetags/perms.py
@@ -34,3 +34,9 @@ register = template.Library()
 def view_academicactors(context):
     user = context['request'].user
     return perms.view_academicactors(user)
+
+
+@register.simple_tag(takes_context=True)
+def view_scores_responsible(context):
+    user = context['request'].user
+    return perms.view_scores_responsible(user)

--- a/base/views/institution.py
+++ b/base/views/institution.py
@@ -27,18 +27,16 @@ import json
 import logging
 
 from django.conf import settings
-from django.contrib.auth.decorators import login_required, permission_required, user_passes_test
+from django.contrib.auth.decorators import login_required, permission_required
 from django.http import JsonResponse, Http404
 from django.shortcuts import get_object_or_404, render
 
 from base import models as mdl
-from base.business import academic_calendar
 from base.business.institution import find_summary_course_submission_dates_for_entity_version
 from base.business.perms import view_academicactors
 from base.forms.entity import EntityVersionFilter
 from base.models import entity_version as entity_version_mdl, entity
 from base.models.academic_year import AcademicYear
-from base.models.entity import Entity
 from base.models.entity_version import EntityVersion
 from base.views.common import paginate_queryset
 from learning_unit.calendar.learning_unit_summary_edition_calendar import LearningUnitSummaryEditionCalendar
@@ -63,7 +61,6 @@ def mandates(request):
 
 
 @login_required
-@user_passes_test(view_academicactors)
 def academic_actors(request):
     return render(request, "academic_actors.html", {})
 


### PR DESCRIPTION
Pull request automatique de feature/OSIS-6254 vers DEV