### PR TITLE
[hotfix/OSIS-6287 => QA] Gestion des classes > formulaire de création/modification > affichage de l_intitulé en français au lieu de l_intitulé en anglais

### DIFF
--- a/learning_unit/templates/class/update.html
+++ b/learning_unit/templates/class/update.html
@@ -147,7 +147,7 @@
                                 <label>
                                     {% trans "Title in English" %}
                                 </label>
-                                {% bootstrap_field form.learning_unit_common_title_fr %}
+                                {% bootstrap_field form.learning_unit_common_title_en %}
                                 {% bootstrap_field form.title_en %}
                             </div>
                         </div>


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-6287 vers QA