### PR TITLE
Check traditional DRF permissions when no mapping is given

### DIFF
--- a/osis_role/tests/contrib/test_views.py
+++ b/osis_role/tests/contrib/test_views.py
@@ -27,6 +27,7 @@ from django.contrib.auth.models import Permission
 from django.test import TestCase
 from django.test.client import RequestFactory
 from rest_framework import status
+from rest_framework.permissions import IsAdminUser
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
@@ -35,10 +36,9 @@ from osis_role.contrib.views import APIPermissionRequiredMixin
 
 
 class TestApiPermissionRequiredMixin(TestCase):
-
     @classmethod
     def setUpTestData(cls):
-        # Tested class
+        # Tested classes
         class TestAPIView(APIPermissionRequiredMixin, APIView):
             permission_mapping = {
                 'GET': 'auth.view_user',
@@ -59,6 +59,14 @@ class TestApiPermissionRequiredMixin(TestCase):
                 return Response()
 
         cls.api_view = TestAPIView
+
+        class TestAPIWithoutMappingView(APIPermissionRequiredMixin, APIView):
+            permission_classes = [IsAdminUser]
+
+            def get(self, request, *args, **kwargs):
+                return Response()
+
+        cls.api_view_without_mapping = TestAPIWithoutMappingView
         cls.factory = RequestFactory()
 
     def test_user_with_right_permissions_string(self):
@@ -136,3 +144,29 @@ class TestApiPermissionRequiredMixin(TestCase):
         response = self.api_view.as_view()(request)
         # Check result -> unauthorized access as the user isn't authenticated
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_without_mapping_as_admin(self):
+        # Create a user with the right permission
+        user = UserFactory(is_staff=True)
+
+        # Simulate a get request with the specified user
+        request = self.factory.get('/osis_role/tests_views/')
+        request.user = user
+        request._force_auth_user = user
+        response = self.api_view_without_mapping.as_view()(request)
+
+        # Check result -> access granted
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_without_mapping_without_permission(self):
+        # Create a user without permissions
+        user = UserFactory()
+
+        # Simulate a get request with the specified user
+        request = self.factory.get('/osis_role/tests_views/')
+        request.user = user
+        request._force_auth_user = user
+        response = self.api_view_without_mapping.as_view()(request)
+
+        # Check result -> access granted
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
Some use cases require logic given request method and object, that cannot be implemented from a single permission, so we process the normal behavior from DRF by mocking a request