### PR TITLE
Upgrade pylint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ django-autocomplete-light==3.5.1
 bleach==3.3.0
 django-cte==1.1.5
 pycodestyle==2.4.0
-pylint==2.4.4
+pylint==2.12.2
 diff-cover==3.0.1
 numpy==1.17.4
 # setuptools 50.0 causes issues


### PR DESCRIPTION
Quelques personnes utilisent Black (https://pypi.org/project/black/) et pylint a une version un peu trop ancienne et nous sort des erreurs de bad-continuation (fixé en [2.6.0](https://github.com/PyCQA/pylint/releases/tag/pylint-2.6.0))