### PR TITLE
OSIS-6430 filter on academic year when searching prerequisites

### DIFF
--- a/program_management/ddd/repositories/tree_prerequisites.py
+++ b/program_management/ddd/repositories/tree_prerequisites.py
@@ -62,7 +62,8 @@ class TreePrerequisitesRepository(interface.AbstractRepository):
             cls,
             entity_ids: Optional[List['EntityIdentity']] = None,
             learning_unit_nodes: List['NodeLearningUnitYear'] = None,
-            tree_root_ids: List['TreeRootId'] = None
+            tree_root_ids: List['TreeRootId'] = None,
+            academic_year: int = None,
     ) -> List['Prerequisites']:
         qs = PrerequisiteItemModel.objects
         if entity_ids:
@@ -72,6 +73,10 @@ class TreePrerequisitesRepository(interface.AbstractRepository):
             qs = qs.filter(
                 Q(prerequisite__learning_unit_year_id__element__pk__in=node_pks)
                 | Q(learning_unit__learningunityear__element__pk__in=node_pks)
+            )
+        if academic_year:
+            qs = qs.filter(
+                prerequisite__learning_unit_year__academic_year__year=academic_year
             )
         if tree_root_ids:
             qs = qs.filter(prerequisite__education_group_version__root_group__element__id__in=tree_root_ids)

--- a/program_management/ddd/validators/_has_or_is_prerequisite.py
+++ b/program_management/ddd/validators/_has_or_is_prerequisite.py
@@ -48,7 +48,10 @@ class IsHasPrerequisiteForAllTreesValidator(business_validator.BusinessValidator
     def validate(self, *args, **kwargs):
         learning_unit_nodes = self.__get_learning_unit_nodes_to_detach()
         if learning_unit_nodes:
-            prerequisites = self.prerequisite_repository.search(learning_unit_nodes=learning_unit_nodes)
+            prerequisites = self.prerequisite_repository.search(
+                learning_unit_nodes=learning_unit_nodes,
+                academic_year=self.parent_node.academic_year.year
+            )
             tree_identities = [p.context_tree for p in prerequisites]
             trees_containing_prerequisites = self.program_tree_repository.search(entity_ids=tree_identities)
             for tree in trees_containing_prerequisites:


### PR DESCRIPTION
When detaching a node from a program, we should check that
we are not breaking prerequisites. However, we should only
check for the academic year on which we are working.

Référence Jira : OSIS-

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis-portal avec les changements effectués dans osis si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
