### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/assessments/tests/business/test_scores_encodings_deadline.py
+++ b/assessments/tests/business/test_scores_encodings_deadline.py
@@ -283,7 +283,7 @@ class ComputeScoresEncodingsDeadlinesTest(TestCase):
         self.assertFalse(mock_compute_deadline.called)
 
     @mock.patch("assessments.business.scores_encodings_deadline.compute_deadline")
-    def test_recompute_all_deadlines_when_not_impact_scores_encodings_deadlines(self, mock_compute_deadline):
+    def test_recompute_all_deadlines_when_not_impact_scores_encodings_deadlines_two(self, mock_compute_deadline):
         OfferYearCalendarFactory(
             academic_calendar=AcademicCalendarFactory(reference=AcademicCalendarTypes.SCORES_EXAM_SUBMISSION.name)
         )

--- a/base/tests/templatetags/test_education_group_pdf.py
+++ b/base/tests/templatetags/test_education_group_pdf.py
@@ -98,7 +98,7 @@ class TestFormatTitleLabel(SimpleTestCase):
         complete_title_label = format_complete_title_label(node, node.group_title_en, node.group_title_fr)
         self.assertEqual(complete_title_label, expected_result)
 
-    def test_format_complete_title_label_with_specific_version_and_title(self):
+    def test_format_complete_title_label_with_specific_version_and_title_two(self):
         node = NodeGroupYearFactory(
             offer_title_fr="Offer title fr",
             offer_title_en="Offer title en",

--- a/ddd/logic/learning_unit/tests/use_case/write/test_update_class_service.py
+++ b/ddd/logic/learning_unit/tests/use_case/write/test_update_class_service.py
@@ -173,7 +173,7 @@ class UpdateClassService(SimpleTestCase):
             DerogationSessionInvalidChoiceException
         )
 
-    def test_should_session_be_valid_choice(self):
+    def test_should_session_be_valid_choice_two(self):
         cmd = attr.evolve(
             self.update_class_cmd,
             session_derogation="invalid choice",

--- a/program_management/tests/ddd/service/write/test_delete_mini_training_with_program_tree_service.py
+++ b/program_management/tests/ddd/service/write/test_delete_mini_training_with_program_tree_service.py
@@ -71,7 +71,7 @@ class DeleteMiniTrainingWithProgramTreeTestCase(DDDTestCase):
         "education_group.ddd.domain.service.link_with_epc.LinkWithEPC.is_mini_training_have_link_with_epc",
         return_value=True
     )
-    def test_cannot_delete_mini_training_for_which_there_is_enrolments(self, mock_has_mini_training_a_link_with_epc):
+    def test_cannot_delete_mini_training_for_which_there_is_enrolments_two(self, mock_has_mini_training_a_link_with_epc):
         with self.assertRaisesBusinessException(MiniTrainingHaveLinkWithEPC):
             delete_mini_training_with_program_tree_service.delete_mini_training_with_program_tree(self.cmd)
 

--- a/program_management/tests/ddd/service/write/test_delete_training_with_program_tree_service.py
+++ b/program_management/tests/ddd/service/write/test_delete_training_with_program_tree_service.py
@@ -96,7 +96,7 @@ class DeleteTrainingWithProgramTreeTestCase(DDDTestCase):
         "education_group.ddd.domain.service.link_with_epc.LinkWithEPC.is_training_have_link_with_epc",
         return_value=True
     )
-    def test_cannot_delete_training_for_which_there_is_enrolments(self, mock_has_training_a_link_with_epc):
+    def test_cannot_delete_training_for_which_there_is_enrolments_two(self, mock_has_training_a_link_with_epc):
         with self.assertRaisesBusinessException(TrainingHaveLinkWithEPC):
             delete_training_with_program_tree_service.delete_training_with_program_tree(self.cmd)
 


### PR DESCRIPTION
Fixes #11572.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

